### PR TITLE
ingest constructor accepts content type and ingest endpoint type

### DIFF
--- a/al_servicec.js
+++ b/al_servicec.js
@@ -163,6 +163,20 @@ class IngestC extends AlServiceC {
         };
         return this.post(`/data/secmsgs`, payload);
     }
+
+    sendVpcFlow(data) {
+        let payload = {
+            json : false,
+            headers : {
+                'Content-Type': 'alertlogic.com/cwl-json',
+                'x-invoked-by' : 'lambda_function',
+                'Content-Encoding' : 'deflate',
+                'Content-Length' : Buffer.byteLength(data)
+            },
+            body : data
+        };
+        return this.post(`/data/vpcflow`, payload);
+    }
 }
 
 

--- a/test/al_mock.js
+++ b/test/al_mock.js
@@ -1,14 +1,14 @@
 
-const AIMS_TEST_CREDS = {
+const AIMS_CREDS = {
     access_key_id: 'test-access-key-id',
     secret_key: 'test-secret-key'
 };
 
-const TEST_AL_API = 'api.test.product.dev.alertlogic.com';
-const INGEST_TEST_URL = '/data/secmsgs';
+const AL_API = 'al-api-endpoint.alertlogic.com';
+const INGEST_API = 'ingest-api-endpoint.alertlogic.com';
 
 module.exports = {
-    TEST_AL_API : TEST_AL_API,
-    AIMS_TEST_CREDS : AIMS_TEST_CREDS,
-    INGEST_TEST_URL : INGEST_TEST_URL
+    AIMS_CREDS : AIMS_CREDS,
+    AL_API : AL_API,
+    INGEST_API : INGEST_API
 };

--- a/test/al_test.js
+++ b/test/al_test.js
@@ -3,20 +3,45 @@ const assert = require('assert');
 const rewire = require('rewire');
 const sinon = require('sinon');
 const m_aimsc = require('../al_servicec').AimsC;
-const cweMock = require('./al_mock');
+const alMock = require('./al_mock');
+const debug = require('debug') ('al_test');
 var servicecRewire = rewire('../al_servicec');
 var m_servicec = require('../al_servicec');
 
 describe('Unit Tests', function() {
 
-    describe('getAlAuth()', function() {
+    describe('IngestC', function() {
+        var fakePost;
 
-        before(function() {
+        afterEach(function() {
+            fakePost.restore();
         });
 
-        afterEach(function() {            
+        it('Verify secmsgs body', function(done) {
+            fakePost = sinon.stub(m_servicec.AlServiceC.prototype, 'post').callsFake(
+                function fakeFn(path, extraOptions) {
+                    assert.equal(extraOptions.headers['Content-Type'], 'alertlogic.com/cwe-json');
+                    assert.equal(path, `/data/secmsgs`);
+
+                    done();
+                });
+
+            var ingest = new m_servicec.IngestC(alMock.INGEST_ENDPOINT, alMock.AIMS_CREDS);
+            ingest.sendSecmsgs("testing payload");
+        });
+
+        it('Verify vpcflow body', function(done) {
+            fakePost = sinon.stub(m_servicec.AlServiceC.prototype, 'post').callsFake(
+                function fakeFn(path, extraOptions) {
+                    assert.equal(extraOptions.headers['Content-Type'], 'alertlogic.com/cwl-json');
+                    assert.equal(path, `/data/vpcflow`);
+
+                    done();
+                });
+
+            var ingest = new m_servicec.IngestC(alMock.INGEST_ENDPOINT, alMock.AIMS_CREDS);
+            ingest.sendVpcFlow("testing payload");
         });
 
     });
-    
 });


### PR DESCRIPTION
**Problem**
Ingest content type is not always `alertlogic.com/cwe-json` and same for `secmsgs` endpoint .

**Solution**
Set endpoint type and content type from a collector and pass it to `IngestC`

Wait for other collectors.

@kkuzmin @ikemsley @alexturkin 