### PR TITLE
Refactor collector type in azcollectc

### DIFF
--- a/al_servicec.js
+++ b/al_servicec.js
@@ -257,8 +257,9 @@ class AzcollectC extends AlServiceC {
             details : checkinValues.details,
             statistics : checkinValues.statistics
         };
+        const type = this._collectorType;
         var functionName = encodeURIComponent(checkinValues.functionName);
-        return this.post(`/aws/${checkinValues.collectorType}/checkin/` +
+        return this.post(`/aws/${type}/checkin/` +
             `${checkinValues.awsAccountId}/${checkinValues.region}/${functionName}`, {body: statusBody});
     }
     
@@ -267,14 +268,16 @@ class AzcollectC extends AlServiceC {
              cf_stack_name : registrationValues.stackName,
              version : registrationValues.version
          }, registrationValues.custom_fields);
+        const type = this._collectorType;
          var functionName = encodeURIComponent(registrationValues.functionName);
-         return this.post(`/aws/${registrationValues.collectorType}/` +
+         return this.post(`/aws/${type}/` +
              `${registrationValues.awsAccountId}/${registrationValues.region}/${functionName}`, {body: statusBody});
      }
 
      _doDeregistrationAws(registrationValues) {
+         const type = this._collectorType;
          var functionName = encodeURIComponent(registrationValues.functionName);
-         return this.deleteRequest(`/aws/${registrationValues.collectorType}/` +
+         return this.deleteRequest(`/aws/${type}/` +
              `${registrationValues.awsAccountId}/${registrationValues.region}/${functionName}`);
      }
     

--- a/test/azcollectc_test.js
+++ b/test/azcollectc_test.js
@@ -48,23 +48,47 @@ describe('Unit Tests', function() {
 
         it('register', function(done) {
             var aimsc = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
-
             var azc = new AzcollectC(m_alMock.INGEST_ENDPOINT, aimsc, 'cwe');
-            azc.register({}).then( resp => {done();});
+            
+            const checkinValues = {
+                awsAccountId : '1234567890',
+                functionName : 'test-function',
+                region : 'us-east-1'
+            };
+            azc.register(checkinValues).then( resp => {
+                sinon.assert.calledWith(fakePost, '/aws/cwe/1234567890/us-east-1/test-function');
+                done();
+            });
         });
         
         it('deregister', function(done) {
             var aimsc = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
-
             var azc = new AzcollectC(m_alMock.INGEST_ENDPOINT, aimsc, 'cwe');
-            azc.deregister({functionName : 'test-fun'}).then( resp => {done();});
+            const checkinValues = {
+                awsAccountId : '1234567890',
+                functionName : 'test-function',
+                region : 'us-east-1'
+            };
+            
+            azc.deregister(checkinValues).then( resp => {
+                sinon.assert.calledWith(fakeDel, '/aws/cwe/1234567890/us-east-1/test-function');
+                done();
+            });
         });
         
         it('checkin', function(done) {
             var aimsc = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
 
             var azc = new AzcollectC(m_alMock.INGEST_ENDPOINT, aimsc, 'cwe');
-            azc.checkin({}).then( resp => {done();});
+            const checkinValues = {
+                awsAccountId : '1234567890',
+                functionName : 'test-function',
+                region : 'us-east-1'
+            };
+            azc.checkin(checkinValues).then( resp => {
+                sinon.assert.calledWith(fakePost, '/aws/cwe/checkin/1234567890/us-east-1/test-function');
+                done();
+            });
         });
 
     });


### PR DESCRIPTION
### Problem Description
There is no need to pass collector type into `register`, `deregister`, `checking`

### Solution Description
Use collector type passed via constructor.
