### PR TITLE
Pass data_type in register request.

### DIFF
--- a/al_servicec.js
+++ b/al_servicec.js
@@ -266,7 +266,8 @@ class AzcollectC extends AlServiceC {
     _doRegistrationAws(registrationValues) {
         let statusBody = Object.assign({
              cf_stack_name : registrationValues.stackName,
-             version : registrationValues.version
+             version : registrationValues.version,
+             data_type : registrationValues.dataType ? registrationValues.dataType : 'secmsgs'
          }, registrationValues.custom_fields);
         const type = this._collectorType;
          var functionName = encodeURIComponent(registrationValues.functionName);

--- a/test/azcollectc_test.js
+++ b/test/azcollectc_test.js
@@ -46,17 +46,54 @@ describe('Unit Tests', function() {
             fakeAuth.restore();
         });
 
-        it('register', function(done) {
+        it('register no data type', function(done) {
             var aimsc = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
             var azc = new AzcollectC(m_alMock.INGEST_ENDPOINT, aimsc, 'cwe');
             
             const checkinValues = {
                 awsAccountId : '1234567890',
                 functionName : 'test-function',
-                region : 'us-east-1'
+                region : 'us-east-1',
+                version : '1.0.0',
+                stackName : 'test-stack'
+                
             };
             azc.register(checkinValues).then( resp => {
-                sinon.assert.calledWith(fakePost, '/aws/cwe/1234567890/us-east-1/test-function');
+                sinon.assert.calledWith(fakePost, '/aws/cwe/1234567890/us-east-1/test-function',
+                    { 
+                        body: {
+                            cf_stack_name: 'test-stack',
+                            data_type: 'secmsgs',
+                            version: '1.0.0'
+                        }
+                    });
+                
+                done();
+            });
+        });
+        
+        it('register with data type', function(done) {
+            var aimsc = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
+            var azc = new AzcollectC(m_alMock.INGEST_ENDPOINT, aimsc, 'cwl');
+            
+            const checkinValues = {
+                awsAccountId : '1234567890',
+                functionName : 'test-function',
+                region : 'us-east-1',
+                version : '1.0.0',
+                stackName : 'test-stack',
+                dataType: 'vpcflow'
+                
+            };
+            azc.register(checkinValues).then( resp => {
+                sinon.assert.calledWith(fakePost, '/aws/cwl/1234567890/us-east-1/test-function',
+                    { 
+                        body: {
+                            cf_stack_name: 'test-stack',
+                            data_type: 'vpcflow',
+                            version: '1.0.0'
+                        }
+                    });
                 done();
             });
         });


### PR DESCRIPTION
### Problem Description
Registration fails due to missed `data_type` in request body.

### Solution Description
Pass `data_type` in register request. Default `secmsgs` for backward compatibility with cwe-collector.

