### PR TITLE
send checkin compressed

### DIFF
--- a/test/al_mock.js
+++ b/test/al_mock.js
@@ -1,3 +1,4 @@
+const zlib = require('zlib');
 
 const AIMS_CREDS = {
     access_key_id: 'test-access-key-id',
@@ -7,8 +8,48 @@ const AIMS_CREDS = {
 const AL_API = 'al-api-endpoint.alertlogic.com';
 const INGEST_API = 'ingest-api-endpoint.alertlogic.com';
 
+const CHECKIN_URL = '/aws/cwe/checkin/1234567890/us-east-1/test-function';
+
+const CHECKIN = {
+    awsAccountId : '1234567890',
+    functionName : 'test-function',
+    region : 'us-east-1',
+    version : '1.0.0',
+    status : 'ok',
+    error_code : undefined,
+    details : [],
+    statistics : undefined
+};
+
+const AZCOLLECT_CHECKIN_QUERY = {
+    body : {
+        version: '1.0.0',
+        status: 'ok',
+        error_code: undefined,
+        details: [],
+        statistics: undefined
+    }
+};
+
+const COMPRESSED_CHECKIN_BODY = zlib.deflateSync(
+    JSON.stringify(AZCOLLECT_CHECKIN_QUERY.body)
+);
+
+const AZCOLLECT_CHECKIN_QUERY_COMPRESSED = {
+    json : false,
+    headers : {
+        'Content-Encoding' : 'deflate',
+        'Content-Length' : Buffer.byteLength(COMPRESSED_CHECKIN_BODY)
+    },
+    body : COMPRESSED_CHECKIN_BODY
+};
+
 module.exports = {
     AIMS_CREDS : AIMS_CREDS,
     AL_API : AL_API,
-    INGEST_API : INGEST_API
+    INGEST_API : INGEST_API,
+    CHECKIN_URL : CHECKIN_URL,
+    CHECKIN : CHECKIN,
+    AZCOLLECT_CHECKIN_QUERY : AZCOLLECT_CHECKIN_QUERY,
+    AZCOLLECT_CHECKIN_QUERY_COMPRESSED : AZCOLLECT_CHECKIN_QUERY_COMPRESSED
 };

--- a/test/azcollectc_test.js
+++ b/test/azcollectc_test.js
@@ -31,7 +31,7 @@ describe('Unit Tests', function() {
                         resolve('ok');
                     });
             });
-            
+
             fakeDel = sinon.stub(AzcollectC.prototype, 'deleteRequest').callsFake(
                     function fakeFn(path, options) {
                         return new Promise(function(resolve, reject) {
@@ -113,17 +113,28 @@ describe('Unit Tests', function() {
             });
         });
         
-        it('checkin', function(done) {
+        it('checkin (no compression)', function(done) {
             var aimsc = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
+            var azc = new AzcollectC(m_alMock.INGEST_ENDPOINT, aimsc, 'cwe', false);
+            azc.checkin(m_alMock.CHECKIN).then( resp => {
+                sinon.assert.calledWith(
+                    fakePost,
+                    m_alMock.CHECKIN_URL,
+                    m_alMock.AZCOLLECT_CHECKIN_QUERY
+                );
+                done();
+            });
+        });
 
-            var azc = new AzcollectC(m_alMock.INGEST_ENDPOINT, aimsc, 'cwe');
-            const checkinValues = {
-                awsAccountId : '1234567890',
-                functionName : 'test-function',
-                region : 'us-east-1'
-            };
-            azc.checkin(checkinValues).then( resp => {
-                sinon.assert.calledWith(fakePost, '/aws/cwe/checkin/1234567890/us-east-1/test-function');
+        it('checkin (with compression)', function(done) {
+            var aimsc = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
+            var azc = new AzcollectC(m_alMock.INGEST_ENDPOINT, aimsc, 'cwe', true);
+            azc.checkin(m_alMock.CHECKIN).then( resp => {
+                sinon.assert.calledWith(
+                    fakePost,
+                    m_alMock.CHECKIN_URL,
+                    m_alMock.AZCOLLECT_CHECKIN_QUERY_COMPRESSED
+                );
                 done();
             });
         });


### PR DESCRIPTION
### Problem Description
As we put `statistics` to checkin, it might occupy too much network bandwidth (and therefore Lambda execution time).

### Solution Description
1) Compress checkin (by default), as CPU is cheaper/faster for Lambda than network
2) Do it configurable (by env variable)

