### PR TITLE
add .AlServiceC to index

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,14 @@
+/* -----------------------------------------------------------------------------
+ * @copyright (C) 2018, Alert Logic, Inc
+ * @doc
+ *
+ * Classes for communication to Alert Logic services.
+ *
+ * @end
+ * -----------------------------------------------------------------------------
+ */
+
+module.exports = {
+    AlServiceC : require('./al_servicec')
+};
+


### PR DESCRIPTION
### Problem Description
We include this library from others by using direct links to filenames:

```
const m_servicec = require('al-collector-js/al_servicec');
```

This is bad practice as it increase lib interface dependency.

### Solution Description
Use index file with specific names


PRs to other libs are to follow.