### PR TITLE
Improve testing coverage

### DIFF
--- a/al_servicec.js
+++ b/al_servicec.js
@@ -49,7 +49,6 @@ class AimsC extends m_alUtil.RestServiceClient {
     }
 
     _makeAuthRequest() {
-
         if (this._isTokenMemCached()) {
             return Promise.race([this._aimsResponse]);
         }

--- a/al_servicec.js
+++ b/al_servicec.js
@@ -49,6 +49,7 @@ class AimsC extends m_alUtil.RestServiceClient {
     }
 
     _makeAuthRequest() {
+
         if (this._isTokenMemCached()) {
             return Promise.race([this._aimsResponse]);
         }
@@ -81,6 +82,7 @@ class AimsC extends m_alUtil.RestServiceClient {
                 if (this._isTokenExpired(tokenJson)) {
                     return false;
                 } else {
+                    this._cid = tokenJson.authentication.account.id;
                     this._aimsResponse = tokenJson;
                     return true;
                 }

--- a/al_servicec.js
+++ b/al_servicec.js
@@ -23,6 +23,7 @@ const COLLECTOR_TYPES = {
     O365 : 'o365'
 };
 
+const TOKEN_EXPIRATION_SAFE_PERIOD = 600; //10 minutes
 
 /**
  * @class
@@ -65,37 +66,39 @@ class AimsC extends m_alUtil.RestServiceClient {
     }
 
     _isTokenExpired(aimsToken) {
-        return aimsToken.authentication.token_expiration <= (Date.now()/1000 + 600);
+        return aimsToken.authentication.token_expiration <=
+               (Date.now()/1000 + TOKEN_EXPIRATION_SAFE_PERIOD);
     }
 
     _isTokenMemCached() {
-        return (this._aimsResponse != undefined) && !this._isTokenExpired(this._aimsResponse);
+        if (this._aimsResponse) {
+            return !this._isTokenExpired(this._aimsResponse);
+        } else {
+            return false;
+        }
     }
 
     _isTokenFileCached() {
         var filename = this._tokenCacheFile;
         try {
             var fileContent = fs.readFileSync(filename);
-            try {
-                var tokenJson = JSON.parse(fileContent);
-                if (this._isTokenExpired(tokenJson)) {
-                    return false;
-                } else {
-                    this._cid = tokenJson.authentication.account.id;
-                    this._aimsResponse = tokenJson;
-                    return true;
-                }
-            } catch (exception) {
-                fs.unlinkSync(filename);
+            var tokenJson = JSON.parse(fileContent);
+            if (this._isTokenExpired(tokenJson)) {
                 return false;
+            } else {
+                this._cid = tokenJson.authentication.account.id;
+                this._aimsResponse = tokenJson;
+                return true;
             }
-        } catch (readErrorException) {
-            if (readErrorException.code !== 'ENOENT') {
+        } catch (e) {
+            if (e instanceof SyntaxError ||
+               ((e instanceof Error) && e.code !== 'ENOENT')) {
                 fs.unlinkSync(filename);
             }
             return false;
         }
     }
+
 
     get cid() {
         return this._cid;

--- a/al_servicec.js
+++ b/al_servicec.js
@@ -370,8 +370,8 @@ class EndpointsC extends AlServiceC {
     constructor(apiEndpoint, aimsCreds) {
         super(apiEndpoint, 'endpoints', 'v1', aimsCreds);
     }
-    getEndpoint(serivceName, residency) {
-        return this.get(`/residency/${residency}/services/${serivceName}/endpoint`, {});
+    getEndpoint(serviceName, residency) {
+        return this.get(`/residency/${residency}/services/${serviceName}/endpoint`, {});
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -13,6 +13,5 @@ module.exports = {
     AlServiceC : require('./al_servicec').AlServiceC,
     IngestC : require('./al_servicec').IngestC,
     AzcollectC : require('./al_servicec').AzcollectC,
-    EndpointsC : require('./al_servicec').EndpointsC,
-    RestServiceClient : require('./al_util').RestServiceClient
+    EndpointsC : require('./al_servicec').EndpointsC
 };

--- a/index.js
+++ b/index.js
@@ -1,0 +1,18 @@
+/* -----------------------------------------------------------------------------
+ * @copyright (C) 2018, Alert Logic, Inc
+ * @doc
+ *
+ * Classes for communication to Alert Logic services.
+ *
+ * @end
+ * -----------------------------------------------------------------------------
+ */
+
+module.exports = {
+    AimsC : require('./al_servicec').AimsC,
+    AlServiceC : require('./al_servicec').AlServiceC,
+    IngestC : require('./al_servicec').IngestC,
+    AzcollectC : require('./al_servicec').AzcollectC,
+    EndpointsC : require('./al_servicec').EndpointsC,
+    RestServiceClient : require('./al_util').RestServiceClient
+};

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "nyc": "^11.3.0",
     "rewire": "^2.5.2",
     "sinon": "^3.3.0",
-    "timekeeper": "^2.1.2"
+    "timekeeper": "^2.1.2",
+    "nock": "^9.3.3"
   },
   "dependencies": {
     "debug": "*",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "mocha-jenkins-reporter": "^0.3.10",
     "nyc": "^11.3.0",
     "rewire": "^2.5.2",
-    "sinon": "^3.3.0"
+    "sinon": "^3.3.0",
+    "timekeeper": "^2.1.2"
   },
   "dependencies": {
     "debug": "*",

--- a/test/aimsc_test.js
+++ b/test/aimsc_test.js
@@ -85,6 +85,7 @@ describe('Unit Tests', function() {
         it('mem cache: test 1) it is used 2) it is renewed after token is expired', function(done) {
             var aimsc = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
             assert_cache(aimsc, false, false);
+            assert.equal(aimsc.cid, undefined);
             aimsc.authenticate()
             .then(resp => {
                 sinon.assert.calledWith(fakeRest,
@@ -92,15 +93,18 @@ describe('Unit Tests', function() {
                 );
                 tk.travel(BEFORE_EXPIRED);
                 assert_cache(aimsc, true, true);
+                assert.equal(aimsc.cid, m_alMock.CID);
                 aimsc.authenticate()
                 .then(resp => {
                     sinon.assert.callCount(fakeRest, 1);
                     tk.travel(AFTER_EXPIRED);
                     assert_cache(aimsc, false, false);
+                    assert.equal(aimsc.cid, m_alMock.CID);
                     aimsc.authenticate()
                     .then(resp => {
                         sinon.assert.callCount(fakeRest, 2);
                         assert_cache(aimsc, true, true);
+                        assert.equal(aimsc.cid, m_alMock.CID);
                         done();
                     });
                 });
@@ -111,6 +115,7 @@ describe('Unit Tests', function() {
         it('file cache: test 1) it is used 2) it is renewed after token is expired', function(done) {
             var aimsc1 = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
             assert_cache(aimsc1, false, false);
+            assert.equal(aimsc1.cid, undefined);
             aimsc1.authenticate()
             .then(resp => {
                 sinon.assert.calledWith(fakeRest,
@@ -120,19 +125,24 @@ describe('Unit Tests', function() {
                 var aimsc2 = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
                 assert_cache(aimsc1, true, true);
                 assert_cache(aimsc2, false, true);
+                assert.equal(aimsc1.cid, m_alMock.CID);
+                assert.equal(aimsc2.cid, m_alMock.CID);
                 aimsc2.authenticate()
                 .then(resp => {
                     sinon.assert.callCount(fakeRest, 1);
                     assert_cache(aimsc2, true, true);
+                    assert.equal(aimsc2.cid, m_alMock.CID);
                     tk.travel(AFTER_EXPIRED);
                     var aimsc3 = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
                     assert_cache(aimsc2, false, false);
                     assert_cache(aimsc3, false, false);
+                    assert.equal(aimsc3.cid, undefined);
                     aimsc3.authenticate()
                     .then(resp => {
                         sinon.assert.callCount(fakeRest, 2);
                         assert_cache(aimsc2, false, true);
                         assert_cache(aimsc3, true, true);
+                        assert.equal(aimsc3.cid, m_alMock.CID);
                         done();
                     });
                 });

--- a/test/aimsc_test.js
+++ b/test/aimsc_test.js
@@ -30,15 +30,7 @@ describe('Unit Tests', function() {
                         options.auth.user == m_alMock.AIMS_AUTH.auth.user &&
                         options.auth.password == m_alMock.AIMS_AUTH.auth.password) {
                         return new Promise(function(resolve, reject) {
-                            resolve({
-                                authentication : {
-                                    token : 'token',
-                                    account : {
-                                        id : m_alMock.CID
-                                    },
-                                    token_expiration : Math.ceil(Date.now()/1000 + m_alMock.AIMS_TOKEN_TTL)
-                                }
-                            });
+                            resolve(m_alMock.gen_token());
                         });
                     } else {
                         return new Promise(function(resolve, reject) {
@@ -182,7 +174,7 @@ function assert_cache(aimsC, expectedMem, expectedFile) {
 
 
 function malform_cache_file(filename) {
-    fs.writeFileSync(filename, "not-a-json");
+    fs.writeFileSync(filename, 'not-a-json');
 }
 
 function assert_file_cache_absent(filename) {

--- a/test/aimsc_test.js
+++ b/test/aimsc_test.js
@@ -1,0 +1,188 @@
+const fs = require('fs');
+const assert = require('assert');
+const rewire = require('rewire');
+const sinon = require('sinon');
+const tk = require('timekeeper');
+const AimsC = require('../al_servicec').AimsC;
+const AzcollectC = require('../al_servicec').AzcollectC;
+const m_alMock = require('./al_mock');
+const debug = require('debug') ('azcollectc_test');
+var servicecRewire = rewire('../al_servicec');
+var m_servicec = require('../al_servicec');
+var RestServiceClient = require('../al_util').RestServiceClient;
+
+const INITIAL_TS = 1529572769;
+const BEFORE_EXPIRED = (INITIAL_TS + 600) * 1000;
+const AFTER_EXPIRED = (INITIAL_TS + m_alMock.AIMS_TOKEN_TTL - 600) * 1000;
+
+
+describe('Unit Tests', function() {
+
+    describe('AimsC', function() {
+        var fakeRest;
+
+        beforeEach(function() {
+            tk.freeze(new Date(INITIAL_TS * 1000));
+
+            fakeRest = sinon.stub(RestServiceClient.prototype, 'post').callsFake(
+                function fakeFn(path, options) {
+                    if (path == '/aims/v1/authenticate' &&
+                        options.auth.user == m_alMock.AIMS_AUTH.auth.user &&
+                        options.auth.password == m_alMock.AIMS_AUTH.auth.password) {
+                        return new Promise(function(resolve, reject) {
+                            resolve({
+                                authentication : {
+                                    token : 'token',
+                                    account : {
+                                        id : m_alMock.CID
+                                    },
+                                    token_expiration : Math.ceil(Date.now()/1000 + m_alMock.AIMS_TOKEN_TTL)
+                                }
+                            });
+                        });
+                    } else {
+                        return new Promise(function(resolve, reject) {
+                            reject('error');
+                        });
+                    }
+                }
+            );
+            clean_file_cache(m_alMock.CACHE_FILENAME);
+        });
+
+        afterEach(function() {
+            fakeRest.restore();
+            tk.reset();
+        });
+
+        after(function() {
+            clean_file_cache(m_alMock.CACHE_FILENAME);
+        });
+
+        it('authenticate with cold cache', function(done) {
+            var aimsc = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
+            assert_cache(aimsc, false, false);
+            aimsc.authenticate()
+            .then(resp => {
+                sinon.assert.calledWith(fakeRest,
+                    '/aims/v1/authenticate', m_alMock.AIMS_AUTH
+                );
+                assert_cache(aimsc, true, true);
+                done();
+            });
+        });
+
+        it('check cid is filled after authenticate() is called', function(done) {
+            var aimsc = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
+            assert.equal(aimsc.cid, null);
+            aimsc.authenticate()
+            .then(resp => {
+                assert.equal(aimsc.cid, m_alMock.CID);
+                done();
+            });
+        });
+
+        it('mem cache: test 1) it is used 2) it is renewed after token is expired', function(done) {
+            var aimsc = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
+            assert_cache(aimsc, false, false);
+            aimsc.authenticate()
+            .then(resp => {
+                sinon.assert.calledWith(fakeRest,
+                    '/aims/v1/authenticate', m_alMock.AIMS_AUTH
+                );
+                tk.travel(BEFORE_EXPIRED);
+                assert_cache(aimsc, true, true);
+                aimsc.authenticate()
+                .then(resp => {
+                    sinon.assert.callCount(fakeRest, 1);
+                    tk.travel(AFTER_EXPIRED);
+                    assert_cache(aimsc, false, false);
+                    aimsc.authenticate()
+                    .then(resp => {
+                        sinon.assert.callCount(fakeRest, 2);
+                        assert_cache(aimsc, true, true);
+                        done();
+                    });
+                });
+            });
+        });
+
+
+        it('file cache: test 1) it is used 2) it is renewed after token is expired', function(done) {
+            var aimsc1 = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
+            assert_cache(aimsc1, false, false);
+            aimsc1.authenticate()
+            .then(resp => {
+                sinon.assert.calledWith(fakeRest,
+                    '/aims/v1/authenticate', m_alMock.AIMS_AUTH
+                );
+                tk.travel(BEFORE_EXPIRED);
+                var aimsc2 = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
+                assert_cache(aimsc1, true, true);
+                assert_cache(aimsc2, false, true);
+                aimsc2.authenticate()
+                .then(resp => {
+                    sinon.assert.callCount(fakeRest, 1);
+                    assert_cache(aimsc2, true, true);
+                    tk.travel(AFTER_EXPIRED);
+                    var aimsc3 = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
+                    assert_cache(aimsc2, false, false);
+                    assert_cache(aimsc3, false, false);
+                    aimsc3.authenticate()
+                    .then(resp => {
+                        sinon.assert.callCount(fakeRest, 2);
+                        assert_cache(aimsc2, false, true);
+                        assert_cache(aimsc3, true, true);
+                        done();
+                    });
+                });
+            });
+        });
+
+        it('file cache: test case when cache file is broken', function(done) {
+            assert_file_cache_absent(m_alMock.CACHE_FILENAME);
+            var aimsc1 = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
+            assert_cache(aimsc1, false, false);
+            aimsc1.authenticate()
+            .then(resp => {
+                tk.travel(BEFORE_EXPIRED);
+                assert_cache(aimsc1, true, true);
+                malform_cache_file(m_alMock.CACHE_FILENAME);
+                var aimsc2 = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
+                assert_cache(aimsc1, true, false);
+                assert_cache(aimsc2, false, false);
+                aimsc2.authenticate()
+                .then(resp => {
+                    sinon.assert.callCount(fakeRest, 2);
+                    assert_cache(aimsc1, true, true);
+                    assert_cache(aimsc2, true, true);
+                    done();
+                });
+            });
+        });
+
+    });
+});
+
+
+function assert_cache(aimsC, expectedMem, expectedFile) {
+    assert.equal(aimsC._isTokenMemCached(), expectedMem);
+    assert.equal(aimsC._isTokenFileCached(), expectedFile);
+}
+
+
+function malform_cache_file(filename) {
+    fs.writeFileSync(filename, "not-a-json");
+}
+
+function assert_file_cache_absent(filename) {
+    assert.throws(() => {fs.readFileSync(filename);});
+}
+
+function clean_file_cache(filename) {
+    try {
+        fs.unlinkSync(filename);
+    } catch (readErrorException) {
+        assert.equal(readErrorException.code, 'ENOENT');
+    }
+}

--- a/test/aimsc_test.js
+++ b/test/aimsc_test.js
@@ -30,7 +30,7 @@ describe('Unit Tests', function() {
                         options.auth.user == m_alMock.AIMS_AUTH.auth.user &&
                         options.auth.password == m_alMock.AIMS_AUTH.auth.password) {
                         return new Promise(function(resolve, reject) {
-                            resolve(m_alMock.gen_token());
+                            resolve(m_alMock.gen_auth_response());
                         });
                     } else {
                         return new Promise(function(resolve, reject) {

--- a/test/al_mock.js
+++ b/test/al_mock.js
@@ -56,6 +56,18 @@ const AZCOLLECT_CHECKIN_QUERY_COMPRESSED = {
     body : COMPRESSED_CHECKIN_BODY
 };
 
+function gen_token() {
+    return {
+        authentication : {
+            token : 'token',
+            account : {
+                id : CID
+            },
+            token_expiration : Math.ceil(Date.now()/1000 + AIMS_TOKEN_TTL)
+        }
+    };
+}
+
 module.exports = {
     AIMS_CREDS : AIMS_CREDS,
     AIMS_AUTH : AIMS_AUTH,
@@ -67,5 +79,7 @@ module.exports = {
     CHECKIN_URL : CHECKIN_URL,
     CHECKIN : CHECKIN,
     AZCOLLECT_CHECKIN_QUERY : AZCOLLECT_CHECKIN_QUERY,
-    AZCOLLECT_CHECKIN_QUERY_COMPRESSED : AZCOLLECT_CHECKIN_QUERY_COMPRESSED
+    AZCOLLECT_CHECKIN_QUERY_COMPRESSED : AZCOLLECT_CHECKIN_QUERY_COMPRESSED,
+
+    gen_token : gen_token
 };

--- a/test/al_mock.js
+++ b/test/al_mock.js
@@ -56,7 +56,7 @@ const AZCOLLECT_CHECKIN_QUERY_COMPRESSED = {
     body : COMPRESSED_CHECKIN_BODY
 };
 
-function gen_token() {
+function gen_auth_response() {
     return {
         authentication : {
             token : 'token',
@@ -81,5 +81,5 @@ module.exports = {
     AZCOLLECT_CHECKIN_QUERY : AZCOLLECT_CHECKIN_QUERY,
     AZCOLLECT_CHECKIN_QUERY_COMPRESSED : AZCOLLECT_CHECKIN_QUERY_COMPRESSED,
 
-    gen_token : gen_token
+    gen_auth_response : gen_auth_response
 };

--- a/test/al_mock.js
+++ b/test/al_mock.js
@@ -5,6 +5,18 @@ const AIMS_CREDS = {
     secret_key: 'test-secret-key'
 };
 
+const AIMS_AUTH = {
+    auth : {
+        user: AIMS_CREDS.access_key_id,
+        password: AIMS_CREDS.secret_key
+    }
+};
+
+const AIMS_TOKEN_TTL = 21600; //6 hours
+const CACHE_FILENAME = '/tmp/' + AIMS_CREDS.access_key_id + '-token.tmp';
+
+const CID = '12345678';
+
 const AL_API = 'al-api-endpoint.alertlogic.com';
 const INGEST_API = 'ingest-api-endpoint.alertlogic.com';
 
@@ -46,6 +58,10 @@ const AZCOLLECT_CHECKIN_QUERY_COMPRESSED = {
 
 module.exports = {
     AIMS_CREDS : AIMS_CREDS,
+    AIMS_AUTH : AIMS_AUTH,
+    AIMS_TOKEN_TTL : AIMS_TOKEN_TTL,
+    CACHE_FILENAME : CACHE_FILENAME,
+    CID : CID,
     AL_API : AL_API,
     INGEST_API : INGEST_API,
     CHECKIN_URL : CHECKIN_URL,

--- a/test/al_util_test.js
+++ b/test/al_util_test.js
@@ -1,0 +1,42 @@
+const assert = require('assert');
+const rewire = require('rewire');
+const sinon = require('sinon');
+const rp = require('request-promise-native');
+const req = require('request');
+const RestServiceClient = require('../al_util').RestServiceClient;
+const m_alMock = require('./al_mock');
+const debug = require('debug') ('azcollectc_test');
+var servicecRewire = rewire('../al_servicec');
+var m_servicec = require('../al_servicec');
+
+describe('Unit Tests', function() {
+
+    describe('RestServiceClient', function() {
+        it('check _initRequestOptions', function(done) {
+            var restC = new RestServiceClient(m_alMock.AL_API);
+            var body = {
+                field1 : true,
+                field2: 'false'
+            };
+            var options = restC._initRequestOptions('POST', '/some/path', {
+                headers : {'some_header' : 'some_value'},
+                body : body
+            });
+            assert.deepEqual(options, {
+                method: 'POST',
+                url: 'https://al-api-endpoint.alertlogic.com/some/path',
+                json: true,
+                headers: {
+                    'some_header' : 'some_value',
+                    'Accept': 'application/json'
+                },
+                pool: {
+                    maxSockets: 128
+                },
+                body : body
+            });
+
+            done();
+        });
+    });
+});

--- a/test/al_util_test.js
+++ b/test/al_util_test.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const rewire = require('rewire');
 const sinon = require('sinon');
+const nock = require('nock');
 const rp = require('request-promise-native');
 const req = require('request');
 const RestServiceClient = require('../al_util').RestServiceClient;
@@ -9,34 +10,110 @@ const debug = require('debug') ('azcollectc_test');
 var servicecRewire = rewire('../al_servicec');
 var m_servicec = require('../al_servicec');
 
+const TEST_PATH = '/some/path';
+const TEST_BODY = {
+    field1 : true,
+    field2: 'false'
+};
+
+
 describe('Unit Tests', function() {
 
     describe('RestServiceClient', function() {
-        it('check _initRequestOptions', function(done) {
+        it('test request', function(done) {
             var restC = new RestServiceClient(m_alMock.AL_API);
-            var body = {
-                field1 : true,
-                field2: 'false'
-            };
-            var options = restC._initRequestOptions('POST', '/some/path', {
+            var restMock = nock('https://' + m_alMock.AL_API, {
+                    reqheaders : {
+                        'accept': 'application/json',
+                        'host': m_alMock.AL_API,
+                        'content-type': 'application/json',
+                        'some_header' : 'some_value'
+                    }
+                })
+                .post(TEST_PATH, TEST_BODY)
+                .times(1)
+                .reply(204);
+            restC.request('POST', TEST_PATH, {
                 headers : {'some_header' : 'some_value'},
-                body : body
+                body : TEST_BODY
+            })
+            .then(resp => {
+                assert.ok(restMock.isDone());
+                done();
             });
-            assert.deepEqual(options, {
-                method: 'POST',
-                url: 'https://al-api-endpoint.alertlogic.com/some/path',
-                json: true,
-                headers: {
-                    'some_header' : 'some_value',
-                    'Accept': 'application/json'
-                },
-                pool: {
-                    maxSockets: 128
-                },
-                body : body
-            });
+        });
 
+        it('test post', function(done) {
+            var restC = new RestServiceClient(m_alMock.AL_API);
+            var restMock = nock('https://' + m_alMock.AL_API, {
+                    reqheaders : {
+                        'accept': 'application/json',
+                        'host': m_alMock.AL_API,
+                        'content-type': 'application/json',
+                        'some_header' : 'some_value'
+                    }
+                })
+                .post(TEST_PATH, TEST_BODY)
+                .times(1)
+                .reply(204);
+            restC.post(TEST_PATH, {
+                headers : {'some_header' : 'some_value'},
+                body : TEST_BODY
+            })
+            .then(resp => {
+                assert.ok(restMock.isDone());
+                done();
+            });
+        });
+
+        it('test get', function(done) {
+            var restC = new RestServiceClient(m_alMock.AL_API);
+            var restMock = nock('https://' + m_alMock.AL_API, {
+                    reqheaders : {
+                        'accept': 'application/json',
+                        'host': m_alMock.AL_API,
+                        'some_header' : 'some_value'
+                    }
+                })
+                .get(TEST_PATH)
+                .times(1)
+                .reply(204);
+            restC.get(TEST_PATH, {
+                headers : {'some_header' : 'some_value'}
+            })
+            .then(resp => {
+                assert.ok(restMock.isDone());
+                done();
+            });
+        });
+
+        it('test deleteRequest', function(done) {
+            var restC = new RestServiceClient(m_alMock.AL_API);
+            var restMock = nock('https://' + m_alMock.AL_API, {
+                    reqheaders : {
+                        'accept': 'application/json',
+                        'host': m_alMock.AL_API,
+                        'some_header' : 'some_value'
+                    }
+                })
+                .delete(TEST_PATH)
+                .times(1)
+                .reply(204);
+            restC.deleteRequest(TEST_PATH, {
+                headers : {'some_header' : 'some_value'}
+            })
+            .then(resp => {
+                assert.ok(restMock.isDone());
+                done();
+            });
+        });
+
+        it('test getters', function(done) {
+            var restC = new RestServiceClient(m_alMock.AL_API);
+            assert.equal(restC.host, m_alMock.AL_API);
+            assert.equal(restC.url, 'https://' + m_alMock.AL_API);
             done();
         });
+
     });
 });

--- a/test/alservicec_test.js
+++ b/test/alservicec_test.js
@@ -1,0 +1,88 @@
+const assert = require('assert');
+const rewire = require('rewire');
+const sinon = require('sinon');
+const AimsC = require('../al_servicec').AimsC;
+const AzcollectC = require('../al_servicec').AzcollectC;
+const AlServiceC = require('../al_servicec').AlServiceC;
+const m_alMock = require('./al_mock');
+const debug = require('debug') ('azcollectc_test');
+var servicecRewire = rewire('../al_servicec');
+var m_servicec = require('../al_servicec');
+var RestServiceClient = require('../al_util').RestServiceClient;
+
+const INITIAL_TS = 1529572769;
+const BEFORE_EXPIRED = (INITIAL_TS + 600) * 1000;
+const AFTER_EXPIRED = (INITIAL_TS + m_alMock.AIMS_TOKEN_TTL - 600) * 1000;
+
+
+describe('Unit Tests', function() {
+
+    describe('AlServiceC', function() {
+        var fakeAims;
+        var fakeRequest;
+
+        beforeEach(function() {
+            fakeAims = sinon.stub(RestServiceClient.prototype, 'post').callsFake(
+                function fakeFn(path, options) {
+                    if (path == '/aims/v1/authenticate' &&
+                        options.auth.user == m_alMock.AIMS_AUTH.auth.user &&
+                        options.auth.password == m_alMock.AIMS_AUTH.auth.password) {
+                        return new Promise(function(resolve, reject) {
+                            resolve({
+                                authentication : {
+                                    token : 'token',
+                                    account : {
+                                        id : m_alMock.CID
+                                    },
+                                    token_expiration : Math.ceil(Date.now()/1000 + m_alMock.AIMS_TOKEN_TTL)
+                                }
+                            });
+                        });
+                    } else {
+                        return new Promise(function(resolve, reject) {
+                            reject('error');
+                        });
+                    }
+                }
+            );
+            fakeRequest = sinon.stub(RestServiceClient.prototype, 'request').callsFake(
+                function fakeFn(method, url, newOptions) {
+                    return new Promise(function(resolve, reject) {
+                        resolve({response : 'some_response'});
+                    });
+                }
+            );
+        });
+
+        afterEach(function() {
+            fakeRequest.restore();
+            fakeAims.restore();
+        });
+
+
+        it('check request is called with correct headers', function(done) {
+            var aimsC = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
+            var alserviceC = new AlServiceC(m_alMock.AL_API, 'service_name', 'v1', aimsC);
+            alserviceC.request('POST', '/some/path', {
+                body : {
+                    field1 : true,
+                    field2: 'false'
+                }
+            })
+            .then(resp => {
+                sinon.assert.calledWith(fakeRequest,
+                    'POST', '/' + m_alMock.CID + '/some/path', {
+                        headers : {
+                            'x-aims-auth-token' : 'token'
+                        },
+                        body : {
+                            field1 : true,
+                            field2: 'false'
+                        }
+                    }
+                );
+                done();
+            });
+        });
+    });
+});

--- a/test/alservicec_test.js
+++ b/test/alservicec_test.js
@@ -24,7 +24,7 @@ describe('Unit Tests', function() {
                         options.auth.user == m_alMock.AIMS_AUTH.auth.user &&
                         options.auth.password == m_alMock.AIMS_AUTH.auth.password) {
                         return new Promise(function(resolve, reject) {
-                            resolve(m_alMock.gen_token());
+                            resolve(m_alMock.gen_auth_response());
                         });
                     } else {
                         return new Promise(function(resolve, reject) {

--- a/test/alservicec_test.js
+++ b/test/alservicec_test.js
@@ -24,15 +24,7 @@ describe('Unit Tests', function() {
                         options.auth.user == m_alMock.AIMS_AUTH.auth.user &&
                         options.auth.password == m_alMock.AIMS_AUTH.auth.password) {
                         return new Promise(function(resolve, reject) {
-                            resolve({
-                                authentication : {
-                                    token : 'token',
-                                    account : {
-                                        id : m_alMock.CID
-                                    },
-                                    token_expiration : Math.ceil(Date.now()/1000 + m_alMock.AIMS_TOKEN_TTL)
-                                }
-                            });
+                            resolve(m_alMock.gen_token());
                         });
                     } else {
                         return new Promise(function(resolve, reject) {

--- a/test/alservicec_test.js
+++ b/test/alservicec_test.js
@@ -10,10 +10,6 @@ var servicecRewire = rewire('../al_servicec');
 var m_servicec = require('../al_servicec');
 var RestServiceClient = require('../al_util').RestServiceClient;
 
-const INITIAL_TS = 1529572769;
-const BEFORE_EXPIRED = (INITIAL_TS + 600) * 1000;
-const AFTER_EXPIRED = (INITIAL_TS + m_alMock.AIMS_TOKEN_TTL - 600) * 1000;
-
 
 describe('Unit Tests', function() {
 
@@ -63,11 +59,12 @@ describe('Unit Tests', function() {
         it('check request is called with correct headers', function(done) {
             var aimsC = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
             var alserviceC = new AlServiceC(m_alMock.AL_API, 'service_name', 'v1', aimsC);
+            var body = {
+                field1 : true,
+                field2: 'false'
+            };
             alserviceC.request('POST', '/some/path', {
-                body : {
-                    field1 : true,
-                    field2: 'false'
-                }
+                body : body
             })
             .then(resp => {
                 sinon.assert.calledWith(fakeRequest,
@@ -75,10 +72,7 @@ describe('Unit Tests', function() {
                         headers : {
                             'x-aims-auth-token' : 'token'
                         },
-                        body : {
-                            field1 : true,
-                            field2: 'false'
-                        }
+                        body : body
                     }
                 );
                 done();

--- a/test/azcollectc_test.js
+++ b/test/azcollectc_test.js
@@ -21,7 +21,7 @@ describe('Unit Tests', function() {
             fakeAuth = sinon.stub(AimsC.prototype, 'authenticate').callsFake(
                 function fakeFn() {
                     return new Promise(function(resolve, reject) {
-                        resolve(m_alMock.gen_token());
+                        resolve(m_alMock.gen_auth_response());
                     });
             });
             

--- a/test/azcollectc_test.js
+++ b/test/azcollectc_test.js
@@ -21,7 +21,7 @@ describe('Unit Tests', function() {
             fakeAuth = sinon.stub(AimsC.prototype, 'authenticate').callsFake(
                 function fakeFn() {
                     return new Promise(function(resolve, reject) {
-                        resolve({authentication : {token : 'token'}});
+                        resolve(m_alMock.gen_token());
                     });
             });
             

--- a/test/endpointc_test.js
+++ b/test/endpointc_test.js
@@ -1,0 +1,53 @@
+const assert = require('assert');
+const rewire = require('rewire');
+const sinon = require('sinon');
+const AimsC = require('../al_servicec').AimsC;
+const AzcollectC = require('../al_servicec').AzcollectC;
+const EndpointsC = require('../al_servicec').EndpointsC;
+const m_alMock = require('./al_mock');
+const debug = require('debug') ('azcollectc_test');
+var servicecRewire = rewire('../al_servicec');
+var m_servicec = require('../al_servicec');
+var RestServiceClient = require('../al_util').RestServiceClient;
+
+describe('Unit Tests', function() {
+
+    describe('EndpointC', function() {
+        var fakeGet;
+        var fakeAuth;
+
+        beforeEach(function() {
+            fakeAuth = sinon.stub(AimsC.prototype, 'authenticate').callsFake(
+                function fakeFn() {
+                    return new Promise(function(resolve, reject) {
+                        resolve({authentication : {token : 'token'}});
+                    });
+            });
+
+            fakeGet = sinon.stub(EndpointsC.prototype, 'get').callsFake(
+                function fakeFn(path, options) {
+                    return new Promise(function(resolve, reject) {
+                        resolve('ok');
+                    });
+            });
+        });
+
+        afterEach(function() {
+            fakeGet.restore();
+            fakeAuth.restore();
+        });
+
+        it('getEndpoint', function(done) {
+            var aimsc = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
+            var endpointsC = new EndpointsC(m_alMock.AL_API, aimsc, 'cwe');
+
+            endpointsC.getEndpoint('azcollect', 'default').then( resp => {
+                sinon.assert.calledWith(fakeGet,
+                    '/residency/default/services/azcollect/endpoint', {}
+                );
+                done();
+            });
+        });
+
+    });
+});

--- a/test/endpointsc_test.js
+++ b/test/endpointsc_test.js
@@ -20,7 +20,7 @@ describe('Unit Tests', function() {
             fakeAuth = sinon.stub(AimsC.prototype, 'authenticate').callsFake(
                 function fakeFn() {
                     return new Promise(function(resolve, reject) {
-                        resolve({authentication : {token : 'token'}});
+                        resolve(m_alMock.gen_token());
                     });
             });
 

--- a/test/endpointsc_test.js
+++ b/test/endpointsc_test.js
@@ -20,7 +20,7 @@ describe('Unit Tests', function() {
             fakeAuth = sinon.stub(AimsC.prototype, 'authenticate').callsFake(
                 function fakeFn() {
                     return new Promise(function(resolve, reject) {
-                        resolve(m_alMock.gen_token());
+                        resolve(m_alMock.gen_auth_response());
                     });
             });
 

--- a/test/ingestc_test.js
+++ b/test/ingestc_test.js
@@ -19,7 +19,7 @@ describe('Unit Tests', function() {
             fakeAuth = sinon.stub(AimsC.prototype, 'authenticate').callsFake(
                 function fakeFn() {
                     return new Promise(function(resolve, reject) {
-                        resolve(m_alMock.gen_token());
+                        resolve(m_alMock.gen_auth_response());
                     });
             });
         });

--- a/test/ingestc_test.js
+++ b/test/ingestc_test.js
@@ -19,7 +19,7 @@ describe('Unit Tests', function() {
             fakeAuth = sinon.stub(AimsC.prototype, 'authenticate').callsFake(
                 function fakeFn() {
                     return new Promise(function(resolve, reject) {
-                        resolve({authentication : {token : 'token'}});
+                        resolve(m_alMock.gen_token());
                     });
             });
         });


### PR DESCRIPTION
- [x] use `mock request` for RestClient tests

### Problem Description
Our testing coverage is quite low for the library.

### Solution Description
* Moar tests! Test coverage is increased:

---
before:
```
 <class name="al_servicec.js" filename="al_servicec.js" line-rate="0.5138" branch-rate="0.425">
 <class name="al_util.js" filename="al_util.js" line-rate="0.36840000000000006" branch-rate="0">
```

after:
```
<class name="al_servicec.js" filename="al_servicec.js" line-rate="0.8273" branch-rate="0.6842">
<class name="al_util.js" filename="al_util.js" line-rate="0.6315999999999999" branch-rate="0.5">
```
---

Tests added:
* AimsC
* EndpointsC
* Al_utils

Tests for `RestServiceClient` are to follow