### PR TITLE
Add log data type support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
-.PHONY: test 
+.PHONY: test deps all compile clean pb pb-clean 
+
+PROTO_DIR=./proto
+
 
 all: test 
 
-deps: node_modules
+deps: node_modules pb
 
 node_modules:
 	npm install
@@ -18,3 +21,10 @@ clean:
 	rm -f package-lock.json
 	rm -f test/report.xml
 	rm -rf ./coverage/
+
+pb: $(PROTO_DIR)
+	cd $(PROTO_DIR) && make compile
+
+pb-clean: $(PROTO_DIR)
+	cd $(PROTO_DIR) && make clean
+

--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ For example:
 }
 ```
 
+# Compiling proto
+
+You will need `pbjs` tool in order to compile protobuf definitions located in [proto](proto):
+
+```
+npm install -g protobufjs
+make pb-clean
+make pb
+```
+
 # Debugging
 
 To get a debug trace, set an Node.js environment variable called DEBUG and
@@ -77,3 +87,4 @@ See [debug](https://www.npmjs.com/package/debug) for further details.
 - [Node.js static code analysis tool](http://jshint.com/install/)
 - [Node.js rewire testing tool](https://github.com/jhnns/rewire)
 - [Node.js sinon testing tool](http://sinonjs.org/)
+- [pbjs manual](http://dcode.io/protobuf.js/#pbjs-for-javascript)

--- a/al_log.js
+++ b/al_log.js
@@ -1,0 +1,247 @@
+/* -----------------------------------------------------------------------------
+ * @copyright (C) 2018, Alert Logic, Inc
+ * @doc
+ *
+ * Helper utilities for  Alert Logic log collector.
+ *
+ * @end
+ * -----------------------------------------------------------------------------
+ */
+const crypto = require('crypto');
+const async = require('async');
+const zlib = require('zlib');
+
+const alcHealthPb = require('./proto/alc_health.piqi_pb').alc_health;
+const commonProtoPb = require('./proto/common_proto.piqi_pb').common_proto;
+const dictPb = require('./proto/dict.piqi_pb').alc_dict;
+const hostMetadataPb = require('./proto/host_metadata.piqi_pb').host_metadata;
+
+const PAYLOAD_BATCH_SIZE = 700000;
+
+/**
+ *  @function builds incoming log messages into protobuf and compresses it. The payload returned is 
+ *  ready to be passed to Ingest client for transport.
+ *  
+ *  @param hostId - host uuid obtained at collector registration
+ *  @param sourceId - source/collector id obtained at collector registration
+ *  @param hostmetaElems - a list of hostmeta JSON objects. For example,
+ *  var hostTypeElem = {
+ *      key: 'host_type',
+ *      value: {str: 'azure_fun'}
+ *  };
+ *  var localHostnameElem = {
+ *      key: 'local_hostname',
+ *      value: {str: process.env.WEBSITE_HOSTNAME}
+ *  };
+ *  var hostmetaElems = [hostTypeElem, localHostnameElem];
+ *  Consult 'metadata' definition in ./proto/host_metadata.piqi.proto
+ *  @param content  - a list of log messages to be ingested. Content should be batched on the caller level.
+ *  @param parseCallback(message) - a function to parse a log message into a JSON object which is converted into protobuf.
+ *  The parse callback is expected to construct the following object out of each log message:
+ *  var parsedMessage = {
+ *      messageTs: 1542138053,
+ *      priority: 11,
+ *      progName: 'o365webhook',
+ *      pid: undefined,
+ *      message: 'some message string',
+ *      messageType: 'json/azure.o365',
+ *      messageTypeId: 'AzureActiveDirectory',
+ *      messageTsUs: undefined
+ *  };
+ *  Consult 'collected_message' definition in proto/common_proto.piqi.proto
+ *  @param callback
+ *  
+ *  @return callback - (error, builtPayload, payloadSize)
+ *  @NOTE: Batch size should be tweaked on a caller level in order to avoid "Maximum payload size exceeded" errors.
+ *  For an Azure function consult eventHub.maxBatchSize property in host.json.
+ *  For an AWS Lambda via kinesis trigger batch size configuration.
+ */
+
+var buildPayload = function (hostId, sourceId, hostmetaElems, content, parseCallback, callback) {
+    async.waterfall([
+        function(callback) {
+            buildMessages(content, parseCallback, function(err, msg) {
+                return callback(err, msg);
+            });
+        },
+        function(msg, callback) {
+            buildHostmeta(hostId, hostmetaElems, function(err, meta) {
+                return callback(err, meta, msg);
+            });
+        },
+        function(meta, msg, callback) {
+            buildBatch(sourceId, meta, msg, function(err, batch) {
+                return callback(err, batch);
+            });
+        },
+        function(batchBuf, callback) {
+            buildBatchList(batchBuf, function(err, batchList) {
+                return callback(err, batchList);
+            });
+        },
+        function(batchList, callback) {
+            var batchListType = commonProtoPb.collected_batch_list;
+            var buf = batchListType.encode(batchList).finish();
+            return callback(null, buf);
+        }],
+        function(err, result) {
+            if (err) {
+                return callback(err);
+            } else {
+                zlib.deflate(result, function(err, compressed) {
+                    if (err) {
+                        return callback(err);
+                    } else {
+                        var payloadSize = compressed.byteLength;
+                        if (payloadSize > PAYLOAD_BATCH_SIZE) {
+                            return callback(`Maximum payload size exceeded: ${payloadSize}`, compressed);
+                        } else {
+                            return callback(null, compressed);
+                        }
+                    }
+                });
+            }
+        });
+};
+
+/**
+ * 
+ * Private functions
+ * 
+ */
+
+function buildType(type, payload, callback) {
+    var verify = type.verify(payload);
+    if (verify)
+        return callback(verify);
+
+    var payloadCreated = type.create(payload);
+
+    return callback(null, payloadCreated);
+}
+
+
+function buildTypeSync(type, payload) {
+    var verify = type.verify(payload);
+    if (verify)
+        throw(verify);
+
+    return type.create(payload);
+}
+
+/**
+ *  @function build hostmeta protobuf out of a list of {key, value} metadata pairs.
+ *  
+ *  @param hostId - a host uuid obtain at collector registration.
+ *  @param hostmetaElems - a list of metadata JSON objects. For example,
+ *  var hostTypeElem = {
+ *      key: 'host_type',
+ *      value: {str: 'azure_fun'}
+ *  };
+ *  var localHostnameElem = {
+ *      key: 'local_hostname',
+ *      value: {str: process.env.WEBSITE_HOSTNAME}
+ *  };
+ *  var hostmetaElems = [hostTypeElem, localHostnameElem];
+ *  
+ *  @param callback
+ *  @returns callback
+ */
+
+function buildHostmeta(hostId, hostmetaElems, callback) {
+    var hostmetaType = hostMetadataPb.metadata;
+    var hostmeta = {
+        elem : hostmetaElems
+    };
+    buildType(dictPb.dict, hostmeta, function(err, hostmetaData){
+        if (err) {
+            return callback(err);
+        } else {
+            var meta = {
+                hostUuid : hostId,
+                data : hostmetaData,
+                dataChecksum : new Buffer('')
+            };
+            var sha = crypto.createHash('sha1');
+            var hashPayload = hostmetaType.encode(meta).finish();
+            hashValue = sha.update(hashPayload).digest();
+            
+            var metadataPayload = {
+                hostUuid : hostId,
+                dataChecksum : hashValue,
+                timestamp : Math.floor(Date.now() / 1000),
+                data : hostmetaData
+            };
+    
+            return buildType(hostmetaType, metadataPayload, callback);
+        }
+    });
+}
+
+/** 
+ * @function builds protobuf out of JSON definition of a log message
+ * @param content - raw log messages retrieved from a source.
+ * @param parseContentFun - function to parse a single message into a json structure. For example,
+ * var parsedMessage = {
+ *      messageTs: 1542138053,
+ *      priority: 11,
+ *      progName: 'o365webhook',
+ *      pid: undefined,
+ *      message: 'some message string',
+ *      messageType: 'json/azure.o365',
+ *      messageTypeId: 'AzureActiveDirectory',
+ *      messageTsUs: undefined
+ *  };
+ *  Consult 'collected_message' definition in proto/common_proto.piqi.proto
+ * @param callback
+ * @returns
+ */
+
+function buildMessages(content, parseContentFun, callback) {
+    async.reduce(content, [], function(memo, item, callback) {
+        var messageType = commonProtoPb.collected_message;
+        var messagePayload = parseContentFun(item);
+        buildType(messageType, messagePayload, function(err, buf) {
+            if (err) {
+                return callback(err);
+            } else {
+                memo.push(buf);
+                return callback(err, memo);
+            }
+        });
+    },
+    callback);
+}
+
+function buildBatch(sId, metadata, messages, callback) {
+    var batchType = commonProtoPb.collected_batch;
+
+    var batchPayload = {
+        sourceId: sId,
+        metadata: metadata,
+        message: messages
+    };
+
+    buildType(batchType, batchPayload, callback);
+}
+
+function buildBatchList(batches, callback) {
+    var batchListType = commonProtoPb.collected_batch_list;
+
+    var batchListPayload = {
+        elem: [batches]
+    };
+
+    buildType(batchListType, batchListPayload, callback);
+}
+
+
+module.exports = {
+    AlcHealthPb : alcHealthPb,
+    CommonProto : commonProtoPb,
+    DictPb : dictPb,
+    HostMetadataPb : hostMetadataPb,
+    buildPayload : buildPayload,
+    PAYLOAD_BATCH_SIZE : PAYLOAD_BATCH_SIZE
+};
+

--- a/al_util.js
+++ b/al_util.js
@@ -18,11 +18,11 @@ let MAX_CONNS_PER_SERVICE = 128;
  */
 let DEFAULT_RETRY = {
     // Default values
-    // factor: 2,
     // randomize: false
-    minTimeout: 3000,
+    factor: 7,
+    minTimeout: 300,
     retries: 2,
-    maxTimeout: 30000
+    maxTimeout: 10000
 };
 
 /**

--- a/al_util.js
+++ b/al_util.js
@@ -2,17 +2,42 @@
  * @copyright (C) 2017, Alert Logic, Inc
  * @doc
  *
- * Helper utilities for  Alert Logic log collector.
+ * Helper utilities for  Alert Logic collectors.
  *
  * @end
  * -----------------------------------------------------------------------------
  */
-'use strict';
 
 const rp = require('request-promise-native');
-const path = require('path');
+const retry = require('retry');
 
 let MAX_CONNS_PER_SERVICE = 128;
+
+/**
+ * @default Refer to https://www.npmjs.com/package/retry
+ */
+let DEFAULT_RETRY = {
+    // Default values
+    // factor: 2,
+    // randomize: false
+    minTimeout: 3000,
+    retries: 2,
+    maxTimeout: 30000
+};
+
+/**
+ * @function Default retry callback. 
+ *  It doesn't retry 2XX, 3XX and 4XX.
+ *  Keeps retrying 5XX HTTP responses and any system level errors
+ **/
+var defaultRetryCb = function(err){
+    if (err.statusCode >= 500 ||
+        (err.error && err.error.errno)) {
+        return true;
+    } else {
+        return false;
+    }
+};
 
 /**
  * @class
@@ -24,14 +49,25 @@ let MAX_CONNS_PER_SERVICE = 128;
  *
  */
 class RestServiceClient {
-    constructor(endpoint) {
+    constructor(endpoint, retryOptions) {
+        'use strict';
         this._host = endpoint;
         this._url = 'https://' + endpoint;
         this._pool = {
             maxSockets: MAX_CONNS_PER_SERVICE
         };
+        if (retryOptions) {
+            this._retryCb = retryOptions.retryCb ? retryOptions.retryCb : defaultRetryCb;
+            delete retryOptions.retryCb;
+            this._retryOptions = retryOptions ? retryOptions : DEFAULT_RETRY;
+        } else {
+            this._retryCb = defaultRetryCb;
+            this._retryOptions = DEFAULT_RETRY;
+        }
     }
+
     _initRequestOptions(method, path, extra) {
+        'use strict';
         const defaultOptions = {
             method: method,
             url: this._url + path,
@@ -49,8 +85,34 @@ class RestServiceClient {
         return options;
     }
     request(method, path, extraOptions) {
+        'use strict';
         const options = this._initRequestOptions(method, path, extraOptions);
-        return rp(options);
+        const retryOptions = this._retryOptions;
+        var retryCb = this._retryCb;
+        
+        var operation = retry.operation(retryOptions);
+        
+        return new Promise(function(resolve, reject) {
+            operation.attempt(function(currentAttempt) {
+                rp(options)
+                    .then( resp => {
+                        // We need opertaion.retry here as we want to check if
+                        // the maximum amount of retries has been reached
+                        if (retryCb(resp) && operation.retry('retry')) {
+                            return;
+                        } else {
+                            return resolve(resp);
+                        }
+                    })
+                    .catch( err =>{
+                        if (retryCb(err) && operation.retry(err)) {
+                            return;
+                        } else {
+                            return reject(err);
+                        }
+                    });
+            });
+        });
     }
     post(path, extraOptions) {
         return this.request('POST', path, extraOptions);

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
  * @copyright (C) 2018, Alert Logic, Inc
  * @doc
  *
- * Classes for communication to Alert Logic services.
+ * Base library for all Alert Logic collectors .
  *
  * @end
  * -----------------------------------------------------------------------------
@@ -13,5 +13,7 @@ module.exports = {
     AlServiceC : require('./al_servicec').AlServiceC,
     IngestC : require('./al_servicec').IngestC,
     AzcollectC : require('./al_servicec').AzcollectC,
-    EndpointsC : require('./al_servicec').EndpointsC
+    EndpointsC : require('./al_servicec').EndpointsC,
+    AlLog : require('./al_log')
 };
+

--- a/package.json
+++ b/package.json
@@ -1,29 +1,30 @@
 {
   "name": "al-collector-js",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Alert Logic Collector Common Library",
   "repository": {},
   "private": true,
   "scripts": {
-    "lint": "jshint --exclude \"./node_modules/*\" **/*.js",
+    "lint": "jshint --exclude \"./node_modules/*,./proto/*\" **/*.js *.js",
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=cobertura mocha --colors --reporter mocha-jenkins-reporter"
   },
   "devDependencies": {
     "jshint": "^2.9.5",
     "mocha": "^3.5.3",
     "mocha-jenkins-reporter": "^0.3.10",
+    "nock": "^10.0.2",
     "nyc": "^11.3.0",
-    "rewire": "^2.5.2",
-    "sinon": "^3.3.0",
-    "timekeeper": "^2.1.2",
-    "nock": "^9.3.3"
+    "sinon": "^7.1.1",
+    "timekeeper": "^2.1.2"
   },
   "dependencies": {
-    "debug": "*",
     "async": "*",
+    "debug": "*",
     "moment": "^2.19.2",
+    "protobufjs": "^6.8.8",
     "request": "*",
-    "request-promise-native": "*"
+    "request-promise-native": "*",
+    "retry": "^0.12.0"
   },
   "author": "Alert Logic Inc."
 }

--- a/proto/Makefile
+++ b/proto/Makefile
@@ -1,0 +1,18 @@
+.PHONY: test all compile clean
+
+PROTOC := $(shell which pbjs)
+
+JS_PROTOS = alc_health.piqi_pb.js common_proto.piqi_pb.js dict.piqi_pb.js host_metadata.piqi_pb.js 
+
+
+all: compile 
+
+%_pb.js: %.proto
+	$(PROTOC) -t static-module -w commonjs -o $@ $< 
+
+compile: $(JS_PROTOS)
+
+
+clean:
+	rm -rf *.js
+

--- a/proto/alc_health.piqi.proto
+++ b/proto/alc_health.piqi.proto
@@ -1,0 +1,28 @@
+package alc_health;
+
+
+message status_update {
+    required status status = 1;
+    required uint64 timestamp = 2;
+    repeated status_update_item item = 3;
+}
+
+enum status {
+    STATUS_OK = 0;
+    STATUS_WARNING = 1;
+    STATUS_ERROR = 2;
+    STATUS_OFFLINE = 3;
+    STATUS_NEW = 4;
+}
+
+message status_update_item {
+    required status_update_item_type type = 1;
+    required string details = 2;
+}
+
+enum status_update_item_type {
+    ERROR_UPDATE = 1;
+    WARNING_UPDATE = 2;
+    INFO_UPDATE = 3;
+}
+

--- a/proto/alc_health.piqi_pb.js
+++ b/proto/alc_health.piqi_pb.js
@@ -1,0 +1,584 @@
+/*eslint-disable block-scoped-var, id-length, no-control-regex, no-magic-numbers, no-prototype-builtins, no-redeclare, no-shadow, no-var, sort-vars*/
+"use strict";
+
+var $protobuf = require("protobufjs/minimal");
+
+// Common aliases
+var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
+
+// Exported root namespace
+var $root = $protobuf.roots["default"] || ($protobuf.roots["default"] = {});
+
+$root.alc_health = (function() {
+
+    /**
+     * Namespace alc_health.
+     * @exports alc_health
+     * @namespace
+     */
+    var alc_health = {};
+
+    alc_health.status_update = (function() {
+
+        /**
+         * Properties of a status_update.
+         * @memberof alc_health
+         * @interface Istatus_update
+         * @property {alc_health.status} status status_update status
+         * @property {number|Long} timestamp status_update timestamp
+         * @property {Array.<alc_health.Istatus_update_item>|null} [item] status_update item
+         */
+
+        /**
+         * Constructs a new status_update.
+         * @memberof alc_health
+         * @classdesc Represents a status_update.
+         * @implements Istatus_update
+         * @constructor
+         * @param {alc_health.Istatus_update=} [properties] Properties to set
+         */
+        function status_update(properties) {
+            this.item = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * status_update status.
+         * @member {alc_health.status} status
+         * @memberof alc_health.status_update
+         * @instance
+         */
+        status_update.prototype.status = 0;
+
+        /**
+         * status_update timestamp.
+         * @member {number|Long} timestamp
+         * @memberof alc_health.status_update
+         * @instance
+         */
+        status_update.prototype.timestamp = $util.Long ? $util.Long.fromBits(0,0,true) : 0;
+
+        /**
+         * status_update item.
+         * @member {Array.<alc_health.Istatus_update_item>} item
+         * @memberof alc_health.status_update
+         * @instance
+         */
+        status_update.prototype.item = $util.emptyArray;
+
+        /**
+         * Creates a new status_update instance using the specified properties.
+         * @function create
+         * @memberof alc_health.status_update
+         * @static
+         * @param {alc_health.Istatus_update=} [properties] Properties to set
+         * @returns {alc_health.status_update} status_update instance
+         */
+        status_update.create = function create(properties) {
+            return new status_update(properties);
+        };
+
+        /**
+         * Encodes the specified status_update message. Does not implicitly {@link alc_health.status_update.verify|verify} messages.
+         * @function encode
+         * @memberof alc_health.status_update
+         * @static
+         * @param {alc_health.Istatus_update} message status_update message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        status_update.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            writer.uint32(/* id 1, wireType 0 =*/8).int32(message.status);
+            writer.uint32(/* id 2, wireType 0 =*/16).uint64(message.timestamp);
+            if (message.item != null && message.item.length)
+                for (var i = 0; i < message.item.length; ++i)
+                    $root.alc_health.status_update_item.encode(message.item[i], writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified status_update message, length delimited. Does not implicitly {@link alc_health.status_update.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof alc_health.status_update
+         * @static
+         * @param {alc_health.Istatus_update} message status_update message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        status_update.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a status_update message from the specified reader or buffer.
+         * @function decode
+         * @memberof alc_health.status_update
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {alc_health.status_update} status_update
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        status_update.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.alc_health.status_update();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.status = reader.int32();
+                    break;
+                case 2:
+                    message.timestamp = reader.uint64();
+                    break;
+                case 3:
+                    if (!(message.item && message.item.length))
+                        message.item = [];
+                    message.item.push($root.alc_health.status_update_item.decode(reader, reader.uint32()));
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            if (!message.hasOwnProperty("status"))
+                throw $util.ProtocolError("missing required 'status'", { instance: message });
+            if (!message.hasOwnProperty("timestamp"))
+                throw $util.ProtocolError("missing required 'timestamp'", { instance: message });
+            return message;
+        };
+
+        /**
+         * Decodes a status_update message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof alc_health.status_update
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {alc_health.status_update} status_update
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        status_update.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a status_update message.
+         * @function verify
+         * @memberof alc_health.status_update
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        status_update.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            switch (message.status) {
+            default:
+                return "status: enum value expected";
+            case 0:
+            case 1:
+            case 2:
+            case 3:
+            case 4:
+                break;
+            }
+            if (!$util.isInteger(message.timestamp) && !(message.timestamp && $util.isInteger(message.timestamp.low) && $util.isInteger(message.timestamp.high)))
+                return "timestamp: integer|Long expected";
+            if (message.item != null && message.hasOwnProperty("item")) {
+                if (!Array.isArray(message.item))
+                    return "item: array expected";
+                for (var i = 0; i < message.item.length; ++i) {
+                    var error = $root.alc_health.status_update_item.verify(message.item[i]);
+                    if (error)
+                        return "item." + error;
+                }
+            }
+            return null;
+        };
+
+        /**
+         * Creates a status_update message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof alc_health.status_update
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {alc_health.status_update} status_update
+         */
+        status_update.fromObject = function fromObject(object) {
+            if (object instanceof $root.alc_health.status_update)
+                return object;
+            var message = new $root.alc_health.status_update();
+            switch (object.status) {
+            case "STATUS_OK":
+            case 0:
+                message.status = 0;
+                break;
+            case "STATUS_WARNING":
+            case 1:
+                message.status = 1;
+                break;
+            case "STATUS_ERROR":
+            case 2:
+                message.status = 2;
+                break;
+            case "STATUS_OFFLINE":
+            case 3:
+                message.status = 3;
+                break;
+            case "STATUS_NEW":
+            case 4:
+                message.status = 4;
+                break;
+            }
+            if (object.timestamp != null)
+                if ($util.Long)
+                    (message.timestamp = $util.Long.fromValue(object.timestamp)).unsigned = true;
+                else if (typeof object.timestamp === "string")
+                    message.timestamp = parseInt(object.timestamp, 10);
+                else if (typeof object.timestamp === "number")
+                    message.timestamp = object.timestamp;
+                else if (typeof object.timestamp === "object")
+                    message.timestamp = new $util.LongBits(object.timestamp.low >>> 0, object.timestamp.high >>> 0).toNumber(true);
+            if (object.item) {
+                if (!Array.isArray(object.item))
+                    throw TypeError(".alc_health.status_update.item: array expected");
+                message.item = [];
+                for (var i = 0; i < object.item.length; ++i) {
+                    if (typeof object.item[i] !== "object")
+                        throw TypeError(".alc_health.status_update.item: object expected");
+                    message.item[i] = $root.alc_health.status_update_item.fromObject(object.item[i]);
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a status_update message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof alc_health.status_update
+         * @static
+         * @param {alc_health.status_update} message status_update
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        status_update.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults)
+                object.item = [];
+            if (options.defaults) {
+                object.status = options.enums === String ? "STATUS_OK" : 0;
+                if ($util.Long) {
+                    var long = new $util.Long(0, 0, true);
+                    object.timestamp = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                } else
+                    object.timestamp = options.longs === String ? "0" : 0;
+            }
+            if (message.status != null && message.hasOwnProperty("status"))
+                object.status = options.enums === String ? $root.alc_health.status[message.status] : message.status;
+            if (message.timestamp != null && message.hasOwnProperty("timestamp"))
+                if (typeof message.timestamp === "number")
+                    object.timestamp = options.longs === String ? String(message.timestamp) : message.timestamp;
+                else
+                    object.timestamp = options.longs === String ? $util.Long.prototype.toString.call(message.timestamp) : options.longs === Number ? new $util.LongBits(message.timestamp.low >>> 0, message.timestamp.high >>> 0).toNumber(true) : message.timestamp;
+            if (message.item && message.item.length) {
+                object.item = [];
+                for (var j = 0; j < message.item.length; ++j)
+                    object.item[j] = $root.alc_health.status_update_item.toObject(message.item[j], options);
+            }
+            return object;
+        };
+
+        /**
+         * Converts this status_update to JSON.
+         * @function toJSON
+         * @memberof alc_health.status_update
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        status_update.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return status_update;
+    })();
+
+    /**
+     * status enum.
+     * @name alc_health.status
+     * @enum {string}
+     * @property {number} STATUS_OK=0 STATUS_OK value
+     * @property {number} STATUS_WARNING=1 STATUS_WARNING value
+     * @property {number} STATUS_ERROR=2 STATUS_ERROR value
+     * @property {number} STATUS_OFFLINE=3 STATUS_OFFLINE value
+     * @property {number} STATUS_NEW=4 STATUS_NEW value
+     */
+    alc_health.status = (function() {
+        var valuesById = {}, values = Object.create(valuesById);
+        values[valuesById[0] = "STATUS_OK"] = 0;
+        values[valuesById[1] = "STATUS_WARNING"] = 1;
+        values[valuesById[2] = "STATUS_ERROR"] = 2;
+        values[valuesById[3] = "STATUS_OFFLINE"] = 3;
+        values[valuesById[4] = "STATUS_NEW"] = 4;
+        return values;
+    })();
+
+    alc_health.status_update_item = (function() {
+
+        /**
+         * Properties of a status_update_item.
+         * @memberof alc_health
+         * @interface Istatus_update_item
+         * @property {alc_health.status_update_item_type} type status_update_item type
+         * @property {string} details status_update_item details
+         */
+
+        /**
+         * Constructs a new status_update_item.
+         * @memberof alc_health
+         * @classdesc Represents a status_update_item.
+         * @implements Istatus_update_item
+         * @constructor
+         * @param {alc_health.Istatus_update_item=} [properties] Properties to set
+         */
+        function status_update_item(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * status_update_item type.
+         * @member {alc_health.status_update_item_type} type
+         * @memberof alc_health.status_update_item
+         * @instance
+         */
+        status_update_item.prototype.type = 1;
+
+        /**
+         * status_update_item details.
+         * @member {string} details
+         * @memberof alc_health.status_update_item
+         * @instance
+         */
+        status_update_item.prototype.details = "";
+
+        /**
+         * Creates a new status_update_item instance using the specified properties.
+         * @function create
+         * @memberof alc_health.status_update_item
+         * @static
+         * @param {alc_health.Istatus_update_item=} [properties] Properties to set
+         * @returns {alc_health.status_update_item} status_update_item instance
+         */
+        status_update_item.create = function create(properties) {
+            return new status_update_item(properties);
+        };
+
+        /**
+         * Encodes the specified status_update_item message. Does not implicitly {@link alc_health.status_update_item.verify|verify} messages.
+         * @function encode
+         * @memberof alc_health.status_update_item
+         * @static
+         * @param {alc_health.Istatus_update_item} message status_update_item message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        status_update_item.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            writer.uint32(/* id 1, wireType 0 =*/8).int32(message.type);
+            writer.uint32(/* id 2, wireType 2 =*/18).string(message.details);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified status_update_item message, length delimited. Does not implicitly {@link alc_health.status_update_item.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof alc_health.status_update_item
+         * @static
+         * @param {alc_health.Istatus_update_item} message status_update_item message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        status_update_item.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a status_update_item message from the specified reader or buffer.
+         * @function decode
+         * @memberof alc_health.status_update_item
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {alc_health.status_update_item} status_update_item
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        status_update_item.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.alc_health.status_update_item();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.type = reader.int32();
+                    break;
+                case 2:
+                    message.details = reader.string();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            if (!message.hasOwnProperty("type"))
+                throw $util.ProtocolError("missing required 'type'", { instance: message });
+            if (!message.hasOwnProperty("details"))
+                throw $util.ProtocolError("missing required 'details'", { instance: message });
+            return message;
+        };
+
+        /**
+         * Decodes a status_update_item message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof alc_health.status_update_item
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {alc_health.status_update_item} status_update_item
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        status_update_item.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a status_update_item message.
+         * @function verify
+         * @memberof alc_health.status_update_item
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        status_update_item.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            switch (message.type) {
+            default:
+                return "type: enum value expected";
+            case 1:
+            case 2:
+            case 3:
+                break;
+            }
+            if (!$util.isString(message.details))
+                return "details: string expected";
+            return null;
+        };
+
+        /**
+         * Creates a status_update_item message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof alc_health.status_update_item
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {alc_health.status_update_item} status_update_item
+         */
+        status_update_item.fromObject = function fromObject(object) {
+            if (object instanceof $root.alc_health.status_update_item)
+                return object;
+            var message = new $root.alc_health.status_update_item();
+            switch (object.type) {
+            case "ERROR_UPDATE":
+            case 1:
+                message.type = 1;
+                break;
+            case "WARNING_UPDATE":
+            case 2:
+                message.type = 2;
+                break;
+            case "INFO_UPDATE":
+            case 3:
+                message.type = 3;
+                break;
+            }
+            if (object.details != null)
+                message.details = String(object.details);
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a status_update_item message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof alc_health.status_update_item
+         * @static
+         * @param {alc_health.status_update_item} message status_update_item
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        status_update_item.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.type = options.enums === String ? "ERROR_UPDATE" : 1;
+                object.details = "";
+            }
+            if (message.type != null && message.hasOwnProperty("type"))
+                object.type = options.enums === String ? $root.alc_health.status_update_item_type[message.type] : message.type;
+            if (message.details != null && message.hasOwnProperty("details"))
+                object.details = message.details;
+            return object;
+        };
+
+        /**
+         * Converts this status_update_item to JSON.
+         * @function toJSON
+         * @memberof alc_health.status_update_item
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        status_update_item.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return status_update_item;
+    })();
+
+    /**
+     * status_update_item_type enum.
+     * @name alc_health.status_update_item_type
+     * @enum {string}
+     * @property {number} ERROR_UPDATE=1 ERROR_UPDATE value
+     * @property {number} WARNING_UPDATE=2 WARNING_UPDATE value
+     * @property {number} INFO_UPDATE=3 INFO_UPDATE value
+     */
+    alc_health.status_update_item_type = (function() {
+        var valuesById = {}, values = Object.create(valuesById);
+        values[valuesById[1] = "ERROR_UPDATE"] = 1;
+        values[valuesById[2] = "WARNING_UPDATE"] = 2;
+        values[valuesById[3] = "INFO_UPDATE"] = 3;
+        return values;
+    })();
+
+    return alc_health;
+})();
+
+module.exports = $root;

--- a/proto/common_proto.piqi.proto
+++ b/proto/common_proto.piqi.proto
@@ -1,0 +1,61 @@
+package common_proto;
+
+import "alc_health.piqi.proto";
+import "host_metadata.piqi.proto";
+
+message collect_input {
+    required string source_id = 1;
+    optional string stream_id = 2;
+    optional bytes previous_stream_state = 3;
+    optional uint32 limit = 4;
+}
+
+message collect_output {
+    required string source_id = 1;
+    optional string stream_id = 2;
+    required bytes new_stream_state = 3;
+    required bool is_end_of_stream = 4;
+    required uint32 collected_events_count = 5;
+    optional uint32 remaining_events_count = 6;
+    optional .alc_health.status_update status = 7;
+}
+
+message collect_error {
+    required string reason = 1;
+    required string source_id = 2;
+    optional string stream_id = 3;
+    optional bool host_wide_error = 4 [default = false];
+    optional .alc_health.status_update status = 5;
+}
+
+message collected_message {
+    optional string hostname = 1;
+    required fixed64 message_ts = 2;
+    required fixed32 priority = 3;
+    optional string prog_name = 4;
+    optional fixed64 pid = 5;
+    required string message = 6;
+    required string message_type = 7;
+    optional string message_type_id = 8;
+    optional fixed32 message_ts_us = 9;
+}
+
+message collected_batch {
+    required string source_id = 1;
+    required .host_metadata.metadata metadata = 2;
+    repeated collected_message message = 3;
+}
+
+message collected_batch_list {
+    repeated collected_batch elem = 1;
+}
+
+message collect_list_input {
+    repeated collect_input sources_list = 1;
+}
+
+message collect_list_output {
+    repeated collect_output collected_sources = 1;
+    repeated collect_error error_sources = 2;
+}
+

--- a/proto/common_proto.piqi_pb.js
+++ b/proto/common_proto.piqi_pb.js
@@ -1,0 +1,4017 @@
+/*eslint-disable block-scoped-var, id-length, no-control-regex, no-magic-numbers, no-prototype-builtins, no-redeclare, no-shadow, no-var, sort-vars*/
+"use strict";
+
+var $protobuf = require("protobufjs/minimal");
+
+// Common aliases
+var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
+
+// Exported root namespace
+var $root = $protobuf.roots["default"] || ($protobuf.roots["default"] = {});
+
+$root.common_proto = (function() {
+
+    /**
+     * Namespace common_proto.
+     * @exports common_proto
+     * @namespace
+     */
+    var common_proto = {};
+
+    common_proto.collect_input = (function() {
+
+        /**
+         * Properties of a collect_input.
+         * @memberof common_proto
+         * @interface Icollect_input
+         * @property {string} sourceId collect_input sourceId
+         * @property {string|null} [streamId] collect_input streamId
+         * @property {Uint8Array|null} [previousStreamState] collect_input previousStreamState
+         * @property {number|null} [limit] collect_input limit
+         */
+
+        /**
+         * Constructs a new collect_input.
+         * @memberof common_proto
+         * @classdesc Represents a collect_input.
+         * @implements Icollect_input
+         * @constructor
+         * @param {common_proto.Icollect_input=} [properties] Properties to set
+         */
+        function collect_input(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * collect_input sourceId.
+         * @member {string} sourceId
+         * @memberof common_proto.collect_input
+         * @instance
+         */
+        collect_input.prototype.sourceId = "";
+
+        /**
+         * collect_input streamId.
+         * @member {string} streamId
+         * @memberof common_proto.collect_input
+         * @instance
+         */
+        collect_input.prototype.streamId = "";
+
+        /**
+         * collect_input previousStreamState.
+         * @member {Uint8Array} previousStreamState
+         * @memberof common_proto.collect_input
+         * @instance
+         */
+        collect_input.prototype.previousStreamState = $util.newBuffer([]);
+
+        /**
+         * collect_input limit.
+         * @member {number} limit
+         * @memberof common_proto.collect_input
+         * @instance
+         */
+        collect_input.prototype.limit = 0;
+
+        /**
+         * Creates a new collect_input instance using the specified properties.
+         * @function create
+         * @memberof common_proto.collect_input
+         * @static
+         * @param {common_proto.Icollect_input=} [properties] Properties to set
+         * @returns {common_proto.collect_input} collect_input instance
+         */
+        collect_input.create = function create(properties) {
+            return new collect_input(properties);
+        };
+
+        /**
+         * Encodes the specified collect_input message. Does not implicitly {@link common_proto.collect_input.verify|verify} messages.
+         * @function encode
+         * @memberof common_proto.collect_input
+         * @static
+         * @param {common_proto.Icollect_input} message collect_input message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        collect_input.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            writer.uint32(/* id 1, wireType 2 =*/10).string(message.sourceId);
+            if (message.streamId != null && message.hasOwnProperty("streamId"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.streamId);
+            if (message.previousStreamState != null && message.hasOwnProperty("previousStreamState"))
+                writer.uint32(/* id 3, wireType 2 =*/26).bytes(message.previousStreamState);
+            if (message.limit != null && message.hasOwnProperty("limit"))
+                writer.uint32(/* id 4, wireType 0 =*/32).uint32(message.limit);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified collect_input message, length delimited. Does not implicitly {@link common_proto.collect_input.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof common_proto.collect_input
+         * @static
+         * @param {common_proto.Icollect_input} message collect_input message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        collect_input.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a collect_input message from the specified reader or buffer.
+         * @function decode
+         * @memberof common_proto.collect_input
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {common_proto.collect_input} collect_input
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        collect_input.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.common_proto.collect_input();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.sourceId = reader.string();
+                    break;
+                case 2:
+                    message.streamId = reader.string();
+                    break;
+                case 3:
+                    message.previousStreamState = reader.bytes();
+                    break;
+                case 4:
+                    message.limit = reader.uint32();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            if (!message.hasOwnProperty("sourceId"))
+                throw $util.ProtocolError("missing required 'sourceId'", { instance: message });
+            return message;
+        };
+
+        /**
+         * Decodes a collect_input message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof common_proto.collect_input
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {common_proto.collect_input} collect_input
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        collect_input.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a collect_input message.
+         * @function verify
+         * @memberof common_proto.collect_input
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        collect_input.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (!$util.isString(message.sourceId))
+                return "sourceId: string expected";
+            if (message.streamId != null && message.hasOwnProperty("streamId"))
+                if (!$util.isString(message.streamId))
+                    return "streamId: string expected";
+            if (message.previousStreamState != null && message.hasOwnProperty("previousStreamState"))
+                if (!(message.previousStreamState && typeof message.previousStreamState.length === "number" || $util.isString(message.previousStreamState)))
+                    return "previousStreamState: buffer expected";
+            if (message.limit != null && message.hasOwnProperty("limit"))
+                if (!$util.isInteger(message.limit))
+                    return "limit: integer expected";
+            return null;
+        };
+
+        /**
+         * Creates a collect_input message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof common_proto.collect_input
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {common_proto.collect_input} collect_input
+         */
+        collect_input.fromObject = function fromObject(object) {
+            if (object instanceof $root.common_proto.collect_input)
+                return object;
+            var message = new $root.common_proto.collect_input();
+            if (object.sourceId != null)
+                message.sourceId = String(object.sourceId);
+            if (object.streamId != null)
+                message.streamId = String(object.streamId);
+            if (object.previousStreamState != null)
+                if (typeof object.previousStreamState === "string")
+                    $util.base64.decode(object.previousStreamState, message.previousStreamState = $util.newBuffer($util.base64.length(object.previousStreamState)), 0);
+                else if (object.previousStreamState.length)
+                    message.previousStreamState = object.previousStreamState;
+            if (object.limit != null)
+                message.limit = object.limit >>> 0;
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a collect_input message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof common_proto.collect_input
+         * @static
+         * @param {common_proto.collect_input} message collect_input
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        collect_input.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.sourceId = "";
+                object.streamId = "";
+                if (options.bytes === String)
+                    object.previousStreamState = "";
+                else {
+                    object.previousStreamState = [];
+                    if (options.bytes !== Array)
+                        object.previousStreamState = $util.newBuffer(object.previousStreamState);
+                }
+                object.limit = 0;
+            }
+            if (message.sourceId != null && message.hasOwnProperty("sourceId"))
+                object.sourceId = message.sourceId;
+            if (message.streamId != null && message.hasOwnProperty("streamId"))
+                object.streamId = message.streamId;
+            if (message.previousStreamState != null && message.hasOwnProperty("previousStreamState"))
+                object.previousStreamState = options.bytes === String ? $util.base64.encode(message.previousStreamState, 0, message.previousStreamState.length) : options.bytes === Array ? Array.prototype.slice.call(message.previousStreamState) : message.previousStreamState;
+            if (message.limit != null && message.hasOwnProperty("limit"))
+                object.limit = message.limit;
+            return object;
+        };
+
+        /**
+         * Converts this collect_input to JSON.
+         * @function toJSON
+         * @memberof common_proto.collect_input
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        collect_input.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return collect_input;
+    })();
+
+    common_proto.collect_output = (function() {
+
+        /**
+         * Properties of a collect_output.
+         * @memberof common_proto
+         * @interface Icollect_output
+         * @property {string} sourceId collect_output sourceId
+         * @property {string|null} [streamId] collect_output streamId
+         * @property {Uint8Array} newStreamState collect_output newStreamState
+         * @property {boolean} isEndOfStream collect_output isEndOfStream
+         * @property {number} collectedEventsCount collect_output collectedEventsCount
+         * @property {number|null} [remainingEventsCount] collect_output remainingEventsCount
+         * @property {alc_health.Istatus_update|null} [status] collect_output status
+         */
+
+        /**
+         * Constructs a new collect_output.
+         * @memberof common_proto
+         * @classdesc Represents a collect_output.
+         * @implements Icollect_output
+         * @constructor
+         * @param {common_proto.Icollect_output=} [properties] Properties to set
+         */
+        function collect_output(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * collect_output sourceId.
+         * @member {string} sourceId
+         * @memberof common_proto.collect_output
+         * @instance
+         */
+        collect_output.prototype.sourceId = "";
+
+        /**
+         * collect_output streamId.
+         * @member {string} streamId
+         * @memberof common_proto.collect_output
+         * @instance
+         */
+        collect_output.prototype.streamId = "";
+
+        /**
+         * collect_output newStreamState.
+         * @member {Uint8Array} newStreamState
+         * @memberof common_proto.collect_output
+         * @instance
+         */
+        collect_output.prototype.newStreamState = $util.newBuffer([]);
+
+        /**
+         * collect_output isEndOfStream.
+         * @member {boolean} isEndOfStream
+         * @memberof common_proto.collect_output
+         * @instance
+         */
+        collect_output.prototype.isEndOfStream = false;
+
+        /**
+         * collect_output collectedEventsCount.
+         * @member {number} collectedEventsCount
+         * @memberof common_proto.collect_output
+         * @instance
+         */
+        collect_output.prototype.collectedEventsCount = 0;
+
+        /**
+         * collect_output remainingEventsCount.
+         * @member {number} remainingEventsCount
+         * @memberof common_proto.collect_output
+         * @instance
+         */
+        collect_output.prototype.remainingEventsCount = 0;
+
+        /**
+         * collect_output status.
+         * @member {alc_health.Istatus_update|null|undefined} status
+         * @memberof common_proto.collect_output
+         * @instance
+         */
+        collect_output.prototype.status = null;
+
+        /**
+         * Creates a new collect_output instance using the specified properties.
+         * @function create
+         * @memberof common_proto.collect_output
+         * @static
+         * @param {common_proto.Icollect_output=} [properties] Properties to set
+         * @returns {common_proto.collect_output} collect_output instance
+         */
+        collect_output.create = function create(properties) {
+            return new collect_output(properties);
+        };
+
+        /**
+         * Encodes the specified collect_output message. Does not implicitly {@link common_proto.collect_output.verify|verify} messages.
+         * @function encode
+         * @memberof common_proto.collect_output
+         * @static
+         * @param {common_proto.Icollect_output} message collect_output message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        collect_output.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            writer.uint32(/* id 1, wireType 2 =*/10).string(message.sourceId);
+            if (message.streamId != null && message.hasOwnProperty("streamId"))
+                writer.uint32(/* id 2, wireType 2 =*/18).string(message.streamId);
+            writer.uint32(/* id 3, wireType 2 =*/26).bytes(message.newStreamState);
+            writer.uint32(/* id 4, wireType 0 =*/32).bool(message.isEndOfStream);
+            writer.uint32(/* id 5, wireType 0 =*/40).uint32(message.collectedEventsCount);
+            if (message.remainingEventsCount != null && message.hasOwnProperty("remainingEventsCount"))
+                writer.uint32(/* id 6, wireType 0 =*/48).uint32(message.remainingEventsCount);
+            if (message.status != null && message.hasOwnProperty("status"))
+                $root.alc_health.status_update.encode(message.status, writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified collect_output message, length delimited. Does not implicitly {@link common_proto.collect_output.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof common_proto.collect_output
+         * @static
+         * @param {common_proto.Icollect_output} message collect_output message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        collect_output.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a collect_output message from the specified reader or buffer.
+         * @function decode
+         * @memberof common_proto.collect_output
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {common_proto.collect_output} collect_output
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        collect_output.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.common_proto.collect_output();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.sourceId = reader.string();
+                    break;
+                case 2:
+                    message.streamId = reader.string();
+                    break;
+                case 3:
+                    message.newStreamState = reader.bytes();
+                    break;
+                case 4:
+                    message.isEndOfStream = reader.bool();
+                    break;
+                case 5:
+                    message.collectedEventsCount = reader.uint32();
+                    break;
+                case 6:
+                    message.remainingEventsCount = reader.uint32();
+                    break;
+                case 7:
+                    message.status = $root.alc_health.status_update.decode(reader, reader.uint32());
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            if (!message.hasOwnProperty("sourceId"))
+                throw $util.ProtocolError("missing required 'sourceId'", { instance: message });
+            if (!message.hasOwnProperty("newStreamState"))
+                throw $util.ProtocolError("missing required 'newStreamState'", { instance: message });
+            if (!message.hasOwnProperty("isEndOfStream"))
+                throw $util.ProtocolError("missing required 'isEndOfStream'", { instance: message });
+            if (!message.hasOwnProperty("collectedEventsCount"))
+                throw $util.ProtocolError("missing required 'collectedEventsCount'", { instance: message });
+            return message;
+        };
+
+        /**
+         * Decodes a collect_output message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof common_proto.collect_output
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {common_proto.collect_output} collect_output
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        collect_output.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a collect_output message.
+         * @function verify
+         * @memberof common_proto.collect_output
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        collect_output.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (!$util.isString(message.sourceId))
+                return "sourceId: string expected";
+            if (message.streamId != null && message.hasOwnProperty("streamId"))
+                if (!$util.isString(message.streamId))
+                    return "streamId: string expected";
+            if (!(message.newStreamState && typeof message.newStreamState.length === "number" || $util.isString(message.newStreamState)))
+                return "newStreamState: buffer expected";
+            if (typeof message.isEndOfStream !== "boolean")
+                return "isEndOfStream: boolean expected";
+            if (!$util.isInteger(message.collectedEventsCount))
+                return "collectedEventsCount: integer expected";
+            if (message.remainingEventsCount != null && message.hasOwnProperty("remainingEventsCount"))
+                if (!$util.isInteger(message.remainingEventsCount))
+                    return "remainingEventsCount: integer expected";
+            if (message.status != null && message.hasOwnProperty("status")) {
+                var error = $root.alc_health.status_update.verify(message.status);
+                if (error)
+                    return "status." + error;
+            }
+            return null;
+        };
+
+        /**
+         * Creates a collect_output message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof common_proto.collect_output
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {common_proto.collect_output} collect_output
+         */
+        collect_output.fromObject = function fromObject(object) {
+            if (object instanceof $root.common_proto.collect_output)
+                return object;
+            var message = new $root.common_proto.collect_output();
+            if (object.sourceId != null)
+                message.sourceId = String(object.sourceId);
+            if (object.streamId != null)
+                message.streamId = String(object.streamId);
+            if (object.newStreamState != null)
+                if (typeof object.newStreamState === "string")
+                    $util.base64.decode(object.newStreamState, message.newStreamState = $util.newBuffer($util.base64.length(object.newStreamState)), 0);
+                else if (object.newStreamState.length)
+                    message.newStreamState = object.newStreamState;
+            if (object.isEndOfStream != null)
+                message.isEndOfStream = Boolean(object.isEndOfStream);
+            if (object.collectedEventsCount != null)
+                message.collectedEventsCount = object.collectedEventsCount >>> 0;
+            if (object.remainingEventsCount != null)
+                message.remainingEventsCount = object.remainingEventsCount >>> 0;
+            if (object.status != null) {
+                if (typeof object.status !== "object")
+                    throw TypeError(".common_proto.collect_output.status: object expected");
+                message.status = $root.alc_health.status_update.fromObject(object.status);
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a collect_output message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof common_proto.collect_output
+         * @static
+         * @param {common_proto.collect_output} message collect_output
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        collect_output.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.sourceId = "";
+                object.streamId = "";
+                if (options.bytes === String)
+                    object.newStreamState = "";
+                else {
+                    object.newStreamState = [];
+                    if (options.bytes !== Array)
+                        object.newStreamState = $util.newBuffer(object.newStreamState);
+                }
+                object.isEndOfStream = false;
+                object.collectedEventsCount = 0;
+                object.remainingEventsCount = 0;
+                object.status = null;
+            }
+            if (message.sourceId != null && message.hasOwnProperty("sourceId"))
+                object.sourceId = message.sourceId;
+            if (message.streamId != null && message.hasOwnProperty("streamId"))
+                object.streamId = message.streamId;
+            if (message.newStreamState != null && message.hasOwnProperty("newStreamState"))
+                object.newStreamState = options.bytes === String ? $util.base64.encode(message.newStreamState, 0, message.newStreamState.length) : options.bytes === Array ? Array.prototype.slice.call(message.newStreamState) : message.newStreamState;
+            if (message.isEndOfStream != null && message.hasOwnProperty("isEndOfStream"))
+                object.isEndOfStream = message.isEndOfStream;
+            if (message.collectedEventsCount != null && message.hasOwnProperty("collectedEventsCount"))
+                object.collectedEventsCount = message.collectedEventsCount;
+            if (message.remainingEventsCount != null && message.hasOwnProperty("remainingEventsCount"))
+                object.remainingEventsCount = message.remainingEventsCount;
+            if (message.status != null && message.hasOwnProperty("status"))
+                object.status = $root.alc_health.status_update.toObject(message.status, options);
+            return object;
+        };
+
+        /**
+         * Converts this collect_output to JSON.
+         * @function toJSON
+         * @memberof common_proto.collect_output
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        collect_output.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return collect_output;
+    })();
+
+    common_proto.collect_error = (function() {
+
+        /**
+         * Properties of a collect_error.
+         * @memberof common_proto
+         * @interface Icollect_error
+         * @property {string} reason collect_error reason
+         * @property {string} sourceId collect_error sourceId
+         * @property {string|null} [streamId] collect_error streamId
+         * @property {boolean|null} [hostWideError] collect_error hostWideError
+         * @property {alc_health.Istatus_update|null} [status] collect_error status
+         */
+
+        /**
+         * Constructs a new collect_error.
+         * @memberof common_proto
+         * @classdesc Represents a collect_error.
+         * @implements Icollect_error
+         * @constructor
+         * @param {common_proto.Icollect_error=} [properties] Properties to set
+         */
+        function collect_error(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * collect_error reason.
+         * @member {string} reason
+         * @memberof common_proto.collect_error
+         * @instance
+         */
+        collect_error.prototype.reason = "";
+
+        /**
+         * collect_error sourceId.
+         * @member {string} sourceId
+         * @memberof common_proto.collect_error
+         * @instance
+         */
+        collect_error.prototype.sourceId = "";
+
+        /**
+         * collect_error streamId.
+         * @member {string} streamId
+         * @memberof common_proto.collect_error
+         * @instance
+         */
+        collect_error.prototype.streamId = "";
+
+        /**
+         * collect_error hostWideError.
+         * @member {boolean} hostWideError
+         * @memberof common_proto.collect_error
+         * @instance
+         */
+        collect_error.prototype.hostWideError = false;
+
+        /**
+         * collect_error status.
+         * @member {alc_health.Istatus_update|null|undefined} status
+         * @memberof common_proto.collect_error
+         * @instance
+         */
+        collect_error.prototype.status = null;
+
+        /**
+         * Creates a new collect_error instance using the specified properties.
+         * @function create
+         * @memberof common_proto.collect_error
+         * @static
+         * @param {common_proto.Icollect_error=} [properties] Properties to set
+         * @returns {common_proto.collect_error} collect_error instance
+         */
+        collect_error.create = function create(properties) {
+            return new collect_error(properties);
+        };
+
+        /**
+         * Encodes the specified collect_error message. Does not implicitly {@link common_proto.collect_error.verify|verify} messages.
+         * @function encode
+         * @memberof common_proto.collect_error
+         * @static
+         * @param {common_proto.Icollect_error} message collect_error message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        collect_error.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            writer.uint32(/* id 1, wireType 2 =*/10).string(message.reason);
+            writer.uint32(/* id 2, wireType 2 =*/18).string(message.sourceId);
+            if (message.streamId != null && message.hasOwnProperty("streamId"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.streamId);
+            if (message.hostWideError != null && message.hasOwnProperty("hostWideError"))
+                writer.uint32(/* id 4, wireType 0 =*/32).bool(message.hostWideError);
+            if (message.status != null && message.hasOwnProperty("status"))
+                $root.alc_health.status_update.encode(message.status, writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified collect_error message, length delimited. Does not implicitly {@link common_proto.collect_error.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof common_proto.collect_error
+         * @static
+         * @param {common_proto.Icollect_error} message collect_error message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        collect_error.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a collect_error message from the specified reader or buffer.
+         * @function decode
+         * @memberof common_proto.collect_error
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {common_proto.collect_error} collect_error
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        collect_error.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.common_proto.collect_error();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.reason = reader.string();
+                    break;
+                case 2:
+                    message.sourceId = reader.string();
+                    break;
+                case 3:
+                    message.streamId = reader.string();
+                    break;
+                case 4:
+                    message.hostWideError = reader.bool();
+                    break;
+                case 5:
+                    message.status = $root.alc_health.status_update.decode(reader, reader.uint32());
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            if (!message.hasOwnProperty("reason"))
+                throw $util.ProtocolError("missing required 'reason'", { instance: message });
+            if (!message.hasOwnProperty("sourceId"))
+                throw $util.ProtocolError("missing required 'sourceId'", { instance: message });
+            return message;
+        };
+
+        /**
+         * Decodes a collect_error message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof common_proto.collect_error
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {common_proto.collect_error} collect_error
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        collect_error.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a collect_error message.
+         * @function verify
+         * @memberof common_proto.collect_error
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        collect_error.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (!$util.isString(message.reason))
+                return "reason: string expected";
+            if (!$util.isString(message.sourceId))
+                return "sourceId: string expected";
+            if (message.streamId != null && message.hasOwnProperty("streamId"))
+                if (!$util.isString(message.streamId))
+                    return "streamId: string expected";
+            if (message.hostWideError != null && message.hasOwnProperty("hostWideError"))
+                if (typeof message.hostWideError !== "boolean")
+                    return "hostWideError: boolean expected";
+            if (message.status != null && message.hasOwnProperty("status")) {
+                var error = $root.alc_health.status_update.verify(message.status);
+                if (error)
+                    return "status." + error;
+            }
+            return null;
+        };
+
+        /**
+         * Creates a collect_error message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof common_proto.collect_error
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {common_proto.collect_error} collect_error
+         */
+        collect_error.fromObject = function fromObject(object) {
+            if (object instanceof $root.common_proto.collect_error)
+                return object;
+            var message = new $root.common_proto.collect_error();
+            if (object.reason != null)
+                message.reason = String(object.reason);
+            if (object.sourceId != null)
+                message.sourceId = String(object.sourceId);
+            if (object.streamId != null)
+                message.streamId = String(object.streamId);
+            if (object.hostWideError != null)
+                message.hostWideError = Boolean(object.hostWideError);
+            if (object.status != null) {
+                if (typeof object.status !== "object")
+                    throw TypeError(".common_proto.collect_error.status: object expected");
+                message.status = $root.alc_health.status_update.fromObject(object.status);
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a collect_error message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof common_proto.collect_error
+         * @static
+         * @param {common_proto.collect_error} message collect_error
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        collect_error.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.reason = "";
+                object.sourceId = "";
+                object.streamId = "";
+                object.hostWideError = false;
+                object.status = null;
+            }
+            if (message.reason != null && message.hasOwnProperty("reason"))
+                object.reason = message.reason;
+            if (message.sourceId != null && message.hasOwnProperty("sourceId"))
+                object.sourceId = message.sourceId;
+            if (message.streamId != null && message.hasOwnProperty("streamId"))
+                object.streamId = message.streamId;
+            if (message.hostWideError != null && message.hasOwnProperty("hostWideError"))
+                object.hostWideError = message.hostWideError;
+            if (message.status != null && message.hasOwnProperty("status"))
+                object.status = $root.alc_health.status_update.toObject(message.status, options);
+            return object;
+        };
+
+        /**
+         * Converts this collect_error to JSON.
+         * @function toJSON
+         * @memberof common_proto.collect_error
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        collect_error.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return collect_error;
+    })();
+
+    common_proto.collected_message = (function() {
+
+        /**
+         * Properties of a collected_message.
+         * @memberof common_proto
+         * @interface Icollected_message
+         * @property {string|null} [hostname] collected_message hostname
+         * @property {number|Long} messageTs collected_message messageTs
+         * @property {number} priority collected_message priority
+         * @property {string|null} [progName] collected_message progName
+         * @property {number|Long|null} [pid] collected_message pid
+         * @property {string} message collected_message message
+         * @property {string} messageType collected_message messageType
+         * @property {string|null} [messageTypeId] collected_message messageTypeId
+         * @property {number|null} [messageTsUs] collected_message messageTsUs
+         */
+
+        /**
+         * Constructs a new collected_message.
+         * @memberof common_proto
+         * @classdesc Represents a collected_message.
+         * @implements Icollected_message
+         * @constructor
+         * @param {common_proto.Icollected_message=} [properties] Properties to set
+         */
+        function collected_message(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * collected_message hostname.
+         * @member {string} hostname
+         * @memberof common_proto.collected_message
+         * @instance
+         */
+        collected_message.prototype.hostname = "";
+
+        /**
+         * collected_message messageTs.
+         * @member {number|Long} messageTs
+         * @memberof common_proto.collected_message
+         * @instance
+         */
+        collected_message.prototype.messageTs = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+
+        /**
+         * collected_message priority.
+         * @member {number} priority
+         * @memberof common_proto.collected_message
+         * @instance
+         */
+        collected_message.prototype.priority = 0;
+
+        /**
+         * collected_message progName.
+         * @member {string} progName
+         * @memberof common_proto.collected_message
+         * @instance
+         */
+        collected_message.prototype.progName = "";
+
+        /**
+         * collected_message pid.
+         * @member {number|Long} pid
+         * @memberof common_proto.collected_message
+         * @instance
+         */
+        collected_message.prototype.pid = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+
+        /**
+         * collected_message message.
+         * @member {string} message
+         * @memberof common_proto.collected_message
+         * @instance
+         */
+        collected_message.prototype.message = "";
+
+        /**
+         * collected_message messageType.
+         * @member {string} messageType
+         * @memberof common_proto.collected_message
+         * @instance
+         */
+        collected_message.prototype.messageType = "";
+
+        /**
+         * collected_message messageTypeId.
+         * @member {string} messageTypeId
+         * @memberof common_proto.collected_message
+         * @instance
+         */
+        collected_message.prototype.messageTypeId = "";
+
+        /**
+         * collected_message messageTsUs.
+         * @member {number} messageTsUs
+         * @memberof common_proto.collected_message
+         * @instance
+         */
+        collected_message.prototype.messageTsUs = 0;
+
+        /**
+         * Creates a new collected_message instance using the specified properties.
+         * @function create
+         * @memberof common_proto.collected_message
+         * @static
+         * @param {common_proto.Icollected_message=} [properties] Properties to set
+         * @returns {common_proto.collected_message} collected_message instance
+         */
+        collected_message.create = function create(properties) {
+            return new collected_message(properties);
+        };
+
+        /**
+         * Encodes the specified collected_message message. Does not implicitly {@link common_proto.collected_message.verify|verify} messages.
+         * @function encode
+         * @memberof common_proto.collected_message
+         * @static
+         * @param {common_proto.Icollected_message} message collected_message message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        collected_message.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.hostname != null && message.hasOwnProperty("hostname"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.hostname);
+            writer.uint32(/* id 2, wireType 1 =*/17).fixed64(message.messageTs);
+            writer.uint32(/* id 3, wireType 5 =*/29).fixed32(message.priority);
+            if (message.progName != null && message.hasOwnProperty("progName"))
+                writer.uint32(/* id 4, wireType 2 =*/34).string(message.progName);
+            if (message.pid != null && message.hasOwnProperty("pid"))
+                writer.uint32(/* id 5, wireType 1 =*/41).fixed64(message.pid);
+            writer.uint32(/* id 6, wireType 2 =*/50).string(message.message);
+            writer.uint32(/* id 7, wireType 2 =*/58).string(message.messageType);
+            if (message.messageTypeId != null && message.hasOwnProperty("messageTypeId"))
+                writer.uint32(/* id 8, wireType 2 =*/66).string(message.messageTypeId);
+            if (message.messageTsUs != null && message.hasOwnProperty("messageTsUs"))
+                writer.uint32(/* id 9, wireType 5 =*/77).fixed32(message.messageTsUs);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified collected_message message, length delimited. Does not implicitly {@link common_proto.collected_message.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof common_proto.collected_message
+         * @static
+         * @param {common_proto.Icollected_message} message collected_message message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        collected_message.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a collected_message message from the specified reader or buffer.
+         * @function decode
+         * @memberof common_proto.collected_message
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {common_proto.collected_message} collected_message
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        collected_message.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.common_proto.collected_message();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.hostname = reader.string();
+                    break;
+                case 2:
+                    message.messageTs = reader.fixed64();
+                    break;
+                case 3:
+                    message.priority = reader.fixed32();
+                    break;
+                case 4:
+                    message.progName = reader.string();
+                    break;
+                case 5:
+                    message.pid = reader.fixed64();
+                    break;
+                case 6:
+                    message.message = reader.string();
+                    break;
+                case 7:
+                    message.messageType = reader.string();
+                    break;
+                case 8:
+                    message.messageTypeId = reader.string();
+                    break;
+                case 9:
+                    message.messageTsUs = reader.fixed32();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            if (!message.hasOwnProperty("messageTs"))
+                throw $util.ProtocolError("missing required 'messageTs'", { instance: message });
+            if (!message.hasOwnProperty("priority"))
+                throw $util.ProtocolError("missing required 'priority'", { instance: message });
+            if (!message.hasOwnProperty("message"))
+                throw $util.ProtocolError("missing required 'message'", { instance: message });
+            if (!message.hasOwnProperty("messageType"))
+                throw $util.ProtocolError("missing required 'messageType'", { instance: message });
+            return message;
+        };
+
+        /**
+         * Decodes a collected_message message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof common_proto.collected_message
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {common_proto.collected_message} collected_message
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        collected_message.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a collected_message message.
+         * @function verify
+         * @memberof common_proto.collected_message
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        collected_message.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.hostname != null && message.hasOwnProperty("hostname"))
+                if (!$util.isString(message.hostname))
+                    return "hostname: string expected";
+            if (!$util.isInteger(message.messageTs) && !(message.messageTs && $util.isInteger(message.messageTs.low) && $util.isInteger(message.messageTs.high)))
+                return "messageTs: integer|Long expected";
+            if (!$util.isInteger(message.priority))
+                return "priority: integer expected";
+            if (message.progName != null && message.hasOwnProperty("progName"))
+                if (!$util.isString(message.progName))
+                    return "progName: string expected";
+            if (message.pid != null && message.hasOwnProperty("pid"))
+                if (!$util.isInteger(message.pid) && !(message.pid && $util.isInteger(message.pid.low) && $util.isInteger(message.pid.high)))
+                    return "pid: integer|Long expected";
+            if (!$util.isString(message.message))
+                return "message: string expected";
+            if (!$util.isString(message.messageType))
+                return "messageType: string expected";
+            if (message.messageTypeId != null && message.hasOwnProperty("messageTypeId"))
+                if (!$util.isString(message.messageTypeId))
+                    return "messageTypeId: string expected";
+            if (message.messageTsUs != null && message.hasOwnProperty("messageTsUs"))
+                if (!$util.isInteger(message.messageTsUs))
+                    return "messageTsUs: integer expected";
+            return null;
+        };
+
+        /**
+         * Creates a collected_message message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof common_proto.collected_message
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {common_proto.collected_message} collected_message
+         */
+        collected_message.fromObject = function fromObject(object) {
+            if (object instanceof $root.common_proto.collected_message)
+                return object;
+            var message = new $root.common_proto.collected_message();
+            if (object.hostname != null)
+                message.hostname = String(object.hostname);
+            if (object.messageTs != null)
+                if ($util.Long)
+                    (message.messageTs = $util.Long.fromValue(object.messageTs)).unsigned = false;
+                else if (typeof object.messageTs === "string")
+                    message.messageTs = parseInt(object.messageTs, 10);
+                else if (typeof object.messageTs === "number")
+                    message.messageTs = object.messageTs;
+                else if (typeof object.messageTs === "object")
+                    message.messageTs = new $util.LongBits(object.messageTs.low >>> 0, object.messageTs.high >>> 0).toNumber();
+            if (object.priority != null)
+                message.priority = object.priority >>> 0;
+            if (object.progName != null)
+                message.progName = String(object.progName);
+            if (object.pid != null)
+                if ($util.Long)
+                    (message.pid = $util.Long.fromValue(object.pid)).unsigned = false;
+                else if (typeof object.pid === "string")
+                    message.pid = parseInt(object.pid, 10);
+                else if (typeof object.pid === "number")
+                    message.pid = object.pid;
+                else if (typeof object.pid === "object")
+                    message.pid = new $util.LongBits(object.pid.low >>> 0, object.pid.high >>> 0).toNumber();
+            if (object.message != null)
+                message.message = String(object.message);
+            if (object.messageType != null)
+                message.messageType = String(object.messageType);
+            if (object.messageTypeId != null)
+                message.messageTypeId = String(object.messageTypeId);
+            if (object.messageTsUs != null)
+                message.messageTsUs = object.messageTsUs >>> 0;
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a collected_message message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof common_proto.collected_message
+         * @static
+         * @param {common_proto.collected_message} message collected_message
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        collected_message.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.hostname = "";
+                if ($util.Long) {
+                    var long = new $util.Long(0, 0, false);
+                    object.messageTs = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                } else
+                    object.messageTs = options.longs === String ? "0" : 0;
+                object.priority = 0;
+                object.progName = "";
+                if ($util.Long) {
+                    var long = new $util.Long(0, 0, false);
+                    object.pid = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                } else
+                    object.pid = options.longs === String ? "0" : 0;
+                object.message = "";
+                object.messageType = "";
+                object.messageTypeId = "";
+                object.messageTsUs = 0;
+            }
+            if (message.hostname != null && message.hasOwnProperty("hostname"))
+                object.hostname = message.hostname;
+            if (message.messageTs != null && message.hasOwnProperty("messageTs"))
+                if (typeof message.messageTs === "number")
+                    object.messageTs = options.longs === String ? String(message.messageTs) : message.messageTs;
+                else
+                    object.messageTs = options.longs === String ? $util.Long.prototype.toString.call(message.messageTs) : options.longs === Number ? new $util.LongBits(message.messageTs.low >>> 0, message.messageTs.high >>> 0).toNumber() : message.messageTs;
+            if (message.priority != null && message.hasOwnProperty("priority"))
+                object.priority = message.priority;
+            if (message.progName != null && message.hasOwnProperty("progName"))
+                object.progName = message.progName;
+            if (message.pid != null && message.hasOwnProperty("pid"))
+                if (typeof message.pid === "number")
+                    object.pid = options.longs === String ? String(message.pid) : message.pid;
+                else
+                    object.pid = options.longs === String ? $util.Long.prototype.toString.call(message.pid) : options.longs === Number ? new $util.LongBits(message.pid.low >>> 0, message.pid.high >>> 0).toNumber() : message.pid;
+            if (message.message != null && message.hasOwnProperty("message"))
+                object.message = message.message;
+            if (message.messageType != null && message.hasOwnProperty("messageType"))
+                object.messageType = message.messageType;
+            if (message.messageTypeId != null && message.hasOwnProperty("messageTypeId"))
+                object.messageTypeId = message.messageTypeId;
+            if (message.messageTsUs != null && message.hasOwnProperty("messageTsUs"))
+                object.messageTsUs = message.messageTsUs;
+            return object;
+        };
+
+        /**
+         * Converts this collected_message to JSON.
+         * @function toJSON
+         * @memberof common_proto.collected_message
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        collected_message.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return collected_message;
+    })();
+
+    common_proto.collected_batch = (function() {
+
+        /**
+         * Properties of a collected_batch.
+         * @memberof common_proto
+         * @interface Icollected_batch
+         * @property {string} sourceId collected_batch sourceId
+         * @property {host_metadata.Imetadata} metadata collected_batch metadata
+         * @property {Array.<common_proto.Icollected_message>|null} [message] collected_batch message
+         */
+
+        /**
+         * Constructs a new collected_batch.
+         * @memberof common_proto
+         * @classdesc Represents a collected_batch.
+         * @implements Icollected_batch
+         * @constructor
+         * @param {common_proto.Icollected_batch=} [properties] Properties to set
+         */
+        function collected_batch(properties) {
+            this.message = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * collected_batch sourceId.
+         * @member {string} sourceId
+         * @memberof common_proto.collected_batch
+         * @instance
+         */
+        collected_batch.prototype.sourceId = "";
+
+        /**
+         * collected_batch metadata.
+         * @member {host_metadata.Imetadata} metadata
+         * @memberof common_proto.collected_batch
+         * @instance
+         */
+        collected_batch.prototype.metadata = null;
+
+        /**
+         * collected_batch message.
+         * @member {Array.<common_proto.Icollected_message>} message
+         * @memberof common_proto.collected_batch
+         * @instance
+         */
+        collected_batch.prototype.message = $util.emptyArray;
+
+        /**
+         * Creates a new collected_batch instance using the specified properties.
+         * @function create
+         * @memberof common_proto.collected_batch
+         * @static
+         * @param {common_proto.Icollected_batch=} [properties] Properties to set
+         * @returns {common_proto.collected_batch} collected_batch instance
+         */
+        collected_batch.create = function create(properties) {
+            return new collected_batch(properties);
+        };
+
+        /**
+         * Encodes the specified collected_batch message. Does not implicitly {@link common_proto.collected_batch.verify|verify} messages.
+         * @function encode
+         * @memberof common_proto.collected_batch
+         * @static
+         * @param {common_proto.Icollected_batch} message collected_batch message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        collected_batch.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            writer.uint32(/* id 1, wireType 2 =*/10).string(message.sourceId);
+            $root.host_metadata.metadata.encode(message.metadata, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            if (message.message != null && message.message.length)
+                for (var i = 0; i < message.message.length; ++i)
+                    $root.common_proto.collected_message.encode(message.message[i], writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified collected_batch message, length delimited. Does not implicitly {@link common_proto.collected_batch.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof common_proto.collected_batch
+         * @static
+         * @param {common_proto.Icollected_batch} message collected_batch message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        collected_batch.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a collected_batch message from the specified reader or buffer.
+         * @function decode
+         * @memberof common_proto.collected_batch
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {common_proto.collected_batch} collected_batch
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        collected_batch.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.common_proto.collected_batch();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.sourceId = reader.string();
+                    break;
+                case 2:
+                    message.metadata = $root.host_metadata.metadata.decode(reader, reader.uint32());
+                    break;
+                case 3:
+                    if (!(message.message && message.message.length))
+                        message.message = [];
+                    message.message.push($root.common_proto.collected_message.decode(reader, reader.uint32()));
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            if (!message.hasOwnProperty("sourceId"))
+                throw $util.ProtocolError("missing required 'sourceId'", { instance: message });
+            if (!message.hasOwnProperty("metadata"))
+                throw $util.ProtocolError("missing required 'metadata'", { instance: message });
+            return message;
+        };
+
+        /**
+         * Decodes a collected_batch message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof common_proto.collected_batch
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {common_proto.collected_batch} collected_batch
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        collected_batch.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a collected_batch message.
+         * @function verify
+         * @memberof common_proto.collected_batch
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        collected_batch.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (!$util.isString(message.sourceId))
+                return "sourceId: string expected";
+            {
+                var error = $root.host_metadata.metadata.verify(message.metadata);
+                if (error)
+                    return "metadata." + error;
+            }
+            if (message.message != null && message.hasOwnProperty("message")) {
+                if (!Array.isArray(message.message))
+                    return "message: array expected";
+                for (var i = 0; i < message.message.length; ++i) {
+                    var error = $root.common_proto.collected_message.verify(message.message[i]);
+                    if (error)
+                        return "message." + error;
+                }
+            }
+            return null;
+        };
+
+        /**
+         * Creates a collected_batch message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof common_proto.collected_batch
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {common_proto.collected_batch} collected_batch
+         */
+        collected_batch.fromObject = function fromObject(object) {
+            if (object instanceof $root.common_proto.collected_batch)
+                return object;
+            var message = new $root.common_proto.collected_batch();
+            if (object.sourceId != null)
+                message.sourceId = String(object.sourceId);
+            if (object.metadata != null) {
+                if (typeof object.metadata !== "object")
+                    throw TypeError(".common_proto.collected_batch.metadata: object expected");
+                message.metadata = $root.host_metadata.metadata.fromObject(object.metadata);
+            }
+            if (object.message) {
+                if (!Array.isArray(object.message))
+                    throw TypeError(".common_proto.collected_batch.message: array expected");
+                message.message = [];
+                for (var i = 0; i < object.message.length; ++i) {
+                    if (typeof object.message[i] !== "object")
+                        throw TypeError(".common_proto.collected_batch.message: object expected");
+                    message.message[i] = $root.common_proto.collected_message.fromObject(object.message[i]);
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a collected_batch message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof common_proto.collected_batch
+         * @static
+         * @param {common_proto.collected_batch} message collected_batch
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        collected_batch.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults)
+                object.message = [];
+            if (options.defaults) {
+                object.sourceId = "";
+                object.metadata = null;
+            }
+            if (message.sourceId != null && message.hasOwnProperty("sourceId"))
+                object.sourceId = message.sourceId;
+            if (message.metadata != null && message.hasOwnProperty("metadata"))
+                object.metadata = $root.host_metadata.metadata.toObject(message.metadata, options);
+            if (message.message && message.message.length) {
+                object.message = [];
+                for (var j = 0; j < message.message.length; ++j)
+                    object.message[j] = $root.common_proto.collected_message.toObject(message.message[j], options);
+            }
+            return object;
+        };
+
+        /**
+         * Converts this collected_batch to JSON.
+         * @function toJSON
+         * @memberof common_proto.collected_batch
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        collected_batch.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return collected_batch;
+    })();
+
+    common_proto.collected_batch_list = (function() {
+
+        /**
+         * Properties of a collected_batch_list.
+         * @memberof common_proto
+         * @interface Icollected_batch_list
+         * @property {Array.<common_proto.Icollected_batch>|null} [elem] collected_batch_list elem
+         */
+
+        /**
+         * Constructs a new collected_batch_list.
+         * @memberof common_proto
+         * @classdesc Represents a collected_batch_list.
+         * @implements Icollected_batch_list
+         * @constructor
+         * @param {common_proto.Icollected_batch_list=} [properties] Properties to set
+         */
+        function collected_batch_list(properties) {
+            this.elem = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * collected_batch_list elem.
+         * @member {Array.<common_proto.Icollected_batch>} elem
+         * @memberof common_proto.collected_batch_list
+         * @instance
+         */
+        collected_batch_list.prototype.elem = $util.emptyArray;
+
+        /**
+         * Creates a new collected_batch_list instance using the specified properties.
+         * @function create
+         * @memberof common_proto.collected_batch_list
+         * @static
+         * @param {common_proto.Icollected_batch_list=} [properties] Properties to set
+         * @returns {common_proto.collected_batch_list} collected_batch_list instance
+         */
+        collected_batch_list.create = function create(properties) {
+            return new collected_batch_list(properties);
+        };
+
+        /**
+         * Encodes the specified collected_batch_list message. Does not implicitly {@link common_proto.collected_batch_list.verify|verify} messages.
+         * @function encode
+         * @memberof common_proto.collected_batch_list
+         * @static
+         * @param {common_proto.Icollected_batch_list} message collected_batch_list message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        collected_batch_list.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.elem != null && message.elem.length)
+                for (var i = 0; i < message.elem.length; ++i)
+                    $root.common_proto.collected_batch.encode(message.elem[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified collected_batch_list message, length delimited. Does not implicitly {@link common_proto.collected_batch_list.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof common_proto.collected_batch_list
+         * @static
+         * @param {common_proto.Icollected_batch_list} message collected_batch_list message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        collected_batch_list.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a collected_batch_list message from the specified reader or buffer.
+         * @function decode
+         * @memberof common_proto.collected_batch_list
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {common_proto.collected_batch_list} collected_batch_list
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        collected_batch_list.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.common_proto.collected_batch_list();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    if (!(message.elem && message.elem.length))
+                        message.elem = [];
+                    message.elem.push($root.common_proto.collected_batch.decode(reader, reader.uint32()));
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a collected_batch_list message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof common_proto.collected_batch_list
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {common_proto.collected_batch_list} collected_batch_list
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        collected_batch_list.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a collected_batch_list message.
+         * @function verify
+         * @memberof common_proto.collected_batch_list
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        collected_batch_list.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.elem != null && message.hasOwnProperty("elem")) {
+                if (!Array.isArray(message.elem))
+                    return "elem: array expected";
+                for (var i = 0; i < message.elem.length; ++i) {
+                    var error = $root.common_proto.collected_batch.verify(message.elem[i]);
+                    if (error)
+                        return "elem." + error;
+                }
+            }
+            return null;
+        };
+
+        /**
+         * Creates a collected_batch_list message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof common_proto.collected_batch_list
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {common_proto.collected_batch_list} collected_batch_list
+         */
+        collected_batch_list.fromObject = function fromObject(object) {
+            if (object instanceof $root.common_proto.collected_batch_list)
+                return object;
+            var message = new $root.common_proto.collected_batch_list();
+            if (object.elem) {
+                if (!Array.isArray(object.elem))
+                    throw TypeError(".common_proto.collected_batch_list.elem: array expected");
+                message.elem = [];
+                for (var i = 0; i < object.elem.length; ++i) {
+                    if (typeof object.elem[i] !== "object")
+                        throw TypeError(".common_proto.collected_batch_list.elem: object expected");
+                    message.elem[i] = $root.common_proto.collected_batch.fromObject(object.elem[i]);
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a collected_batch_list message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof common_proto.collected_batch_list
+         * @static
+         * @param {common_proto.collected_batch_list} message collected_batch_list
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        collected_batch_list.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults)
+                object.elem = [];
+            if (message.elem && message.elem.length) {
+                object.elem = [];
+                for (var j = 0; j < message.elem.length; ++j)
+                    object.elem[j] = $root.common_proto.collected_batch.toObject(message.elem[j], options);
+            }
+            return object;
+        };
+
+        /**
+         * Converts this collected_batch_list to JSON.
+         * @function toJSON
+         * @memberof common_proto.collected_batch_list
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        collected_batch_list.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return collected_batch_list;
+    })();
+
+    common_proto.collect_list_input = (function() {
+
+        /**
+         * Properties of a collect_list_input.
+         * @memberof common_proto
+         * @interface Icollect_list_input
+         * @property {Array.<common_proto.Icollect_input>|null} [sourcesList] collect_list_input sourcesList
+         */
+
+        /**
+         * Constructs a new collect_list_input.
+         * @memberof common_proto
+         * @classdesc Represents a collect_list_input.
+         * @implements Icollect_list_input
+         * @constructor
+         * @param {common_proto.Icollect_list_input=} [properties] Properties to set
+         */
+        function collect_list_input(properties) {
+            this.sourcesList = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * collect_list_input sourcesList.
+         * @member {Array.<common_proto.Icollect_input>} sourcesList
+         * @memberof common_proto.collect_list_input
+         * @instance
+         */
+        collect_list_input.prototype.sourcesList = $util.emptyArray;
+
+        /**
+         * Creates a new collect_list_input instance using the specified properties.
+         * @function create
+         * @memberof common_proto.collect_list_input
+         * @static
+         * @param {common_proto.Icollect_list_input=} [properties] Properties to set
+         * @returns {common_proto.collect_list_input} collect_list_input instance
+         */
+        collect_list_input.create = function create(properties) {
+            return new collect_list_input(properties);
+        };
+
+        /**
+         * Encodes the specified collect_list_input message. Does not implicitly {@link common_proto.collect_list_input.verify|verify} messages.
+         * @function encode
+         * @memberof common_proto.collect_list_input
+         * @static
+         * @param {common_proto.Icollect_list_input} message collect_list_input message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        collect_list_input.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.sourcesList != null && message.sourcesList.length)
+                for (var i = 0; i < message.sourcesList.length; ++i)
+                    $root.common_proto.collect_input.encode(message.sourcesList[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified collect_list_input message, length delimited. Does not implicitly {@link common_proto.collect_list_input.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof common_proto.collect_list_input
+         * @static
+         * @param {common_proto.Icollect_list_input} message collect_list_input message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        collect_list_input.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a collect_list_input message from the specified reader or buffer.
+         * @function decode
+         * @memberof common_proto.collect_list_input
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {common_proto.collect_list_input} collect_list_input
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        collect_list_input.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.common_proto.collect_list_input();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    if (!(message.sourcesList && message.sourcesList.length))
+                        message.sourcesList = [];
+                    message.sourcesList.push($root.common_proto.collect_input.decode(reader, reader.uint32()));
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a collect_list_input message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof common_proto.collect_list_input
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {common_proto.collect_list_input} collect_list_input
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        collect_list_input.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a collect_list_input message.
+         * @function verify
+         * @memberof common_proto.collect_list_input
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        collect_list_input.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.sourcesList != null && message.hasOwnProperty("sourcesList")) {
+                if (!Array.isArray(message.sourcesList))
+                    return "sourcesList: array expected";
+                for (var i = 0; i < message.sourcesList.length; ++i) {
+                    var error = $root.common_proto.collect_input.verify(message.sourcesList[i]);
+                    if (error)
+                        return "sourcesList." + error;
+                }
+            }
+            return null;
+        };
+
+        /**
+         * Creates a collect_list_input message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof common_proto.collect_list_input
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {common_proto.collect_list_input} collect_list_input
+         */
+        collect_list_input.fromObject = function fromObject(object) {
+            if (object instanceof $root.common_proto.collect_list_input)
+                return object;
+            var message = new $root.common_proto.collect_list_input();
+            if (object.sourcesList) {
+                if (!Array.isArray(object.sourcesList))
+                    throw TypeError(".common_proto.collect_list_input.sourcesList: array expected");
+                message.sourcesList = [];
+                for (var i = 0; i < object.sourcesList.length; ++i) {
+                    if (typeof object.sourcesList[i] !== "object")
+                        throw TypeError(".common_proto.collect_list_input.sourcesList: object expected");
+                    message.sourcesList[i] = $root.common_proto.collect_input.fromObject(object.sourcesList[i]);
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a collect_list_input message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof common_proto.collect_list_input
+         * @static
+         * @param {common_proto.collect_list_input} message collect_list_input
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        collect_list_input.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults)
+                object.sourcesList = [];
+            if (message.sourcesList && message.sourcesList.length) {
+                object.sourcesList = [];
+                for (var j = 0; j < message.sourcesList.length; ++j)
+                    object.sourcesList[j] = $root.common_proto.collect_input.toObject(message.sourcesList[j], options);
+            }
+            return object;
+        };
+
+        /**
+         * Converts this collect_list_input to JSON.
+         * @function toJSON
+         * @memberof common_proto.collect_list_input
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        collect_list_input.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return collect_list_input;
+    })();
+
+    common_proto.collect_list_output = (function() {
+
+        /**
+         * Properties of a collect_list_output.
+         * @memberof common_proto
+         * @interface Icollect_list_output
+         * @property {Array.<common_proto.Icollect_output>|null} [collectedSources] collect_list_output collectedSources
+         * @property {Array.<common_proto.Icollect_error>|null} [errorSources] collect_list_output errorSources
+         */
+
+        /**
+         * Constructs a new collect_list_output.
+         * @memberof common_proto
+         * @classdesc Represents a collect_list_output.
+         * @implements Icollect_list_output
+         * @constructor
+         * @param {common_proto.Icollect_list_output=} [properties] Properties to set
+         */
+        function collect_list_output(properties) {
+            this.collectedSources = [];
+            this.errorSources = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * collect_list_output collectedSources.
+         * @member {Array.<common_proto.Icollect_output>} collectedSources
+         * @memberof common_proto.collect_list_output
+         * @instance
+         */
+        collect_list_output.prototype.collectedSources = $util.emptyArray;
+
+        /**
+         * collect_list_output errorSources.
+         * @member {Array.<common_proto.Icollect_error>} errorSources
+         * @memberof common_proto.collect_list_output
+         * @instance
+         */
+        collect_list_output.prototype.errorSources = $util.emptyArray;
+
+        /**
+         * Creates a new collect_list_output instance using the specified properties.
+         * @function create
+         * @memberof common_proto.collect_list_output
+         * @static
+         * @param {common_proto.Icollect_list_output=} [properties] Properties to set
+         * @returns {common_proto.collect_list_output} collect_list_output instance
+         */
+        collect_list_output.create = function create(properties) {
+            return new collect_list_output(properties);
+        };
+
+        /**
+         * Encodes the specified collect_list_output message. Does not implicitly {@link common_proto.collect_list_output.verify|verify} messages.
+         * @function encode
+         * @memberof common_proto.collect_list_output
+         * @static
+         * @param {common_proto.Icollect_list_output} message collect_list_output message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        collect_list_output.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.collectedSources != null && message.collectedSources.length)
+                for (var i = 0; i < message.collectedSources.length; ++i)
+                    $root.common_proto.collect_output.encode(message.collectedSources[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            if (message.errorSources != null && message.errorSources.length)
+                for (var i = 0; i < message.errorSources.length; ++i)
+                    $root.common_proto.collect_error.encode(message.errorSources[i], writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified collect_list_output message, length delimited. Does not implicitly {@link common_proto.collect_list_output.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof common_proto.collect_list_output
+         * @static
+         * @param {common_proto.Icollect_list_output} message collect_list_output message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        collect_list_output.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a collect_list_output message from the specified reader or buffer.
+         * @function decode
+         * @memberof common_proto.collect_list_output
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {common_proto.collect_list_output} collect_list_output
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        collect_list_output.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.common_proto.collect_list_output();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    if (!(message.collectedSources && message.collectedSources.length))
+                        message.collectedSources = [];
+                    message.collectedSources.push($root.common_proto.collect_output.decode(reader, reader.uint32()));
+                    break;
+                case 2:
+                    if (!(message.errorSources && message.errorSources.length))
+                        message.errorSources = [];
+                    message.errorSources.push($root.common_proto.collect_error.decode(reader, reader.uint32()));
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a collect_list_output message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof common_proto.collect_list_output
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {common_proto.collect_list_output} collect_list_output
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        collect_list_output.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a collect_list_output message.
+         * @function verify
+         * @memberof common_proto.collect_list_output
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        collect_list_output.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.collectedSources != null && message.hasOwnProperty("collectedSources")) {
+                if (!Array.isArray(message.collectedSources))
+                    return "collectedSources: array expected";
+                for (var i = 0; i < message.collectedSources.length; ++i) {
+                    var error = $root.common_proto.collect_output.verify(message.collectedSources[i]);
+                    if (error)
+                        return "collectedSources." + error;
+                }
+            }
+            if (message.errorSources != null && message.hasOwnProperty("errorSources")) {
+                if (!Array.isArray(message.errorSources))
+                    return "errorSources: array expected";
+                for (var i = 0; i < message.errorSources.length; ++i) {
+                    var error = $root.common_proto.collect_error.verify(message.errorSources[i]);
+                    if (error)
+                        return "errorSources." + error;
+                }
+            }
+            return null;
+        };
+
+        /**
+         * Creates a collect_list_output message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof common_proto.collect_list_output
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {common_proto.collect_list_output} collect_list_output
+         */
+        collect_list_output.fromObject = function fromObject(object) {
+            if (object instanceof $root.common_proto.collect_list_output)
+                return object;
+            var message = new $root.common_proto.collect_list_output();
+            if (object.collectedSources) {
+                if (!Array.isArray(object.collectedSources))
+                    throw TypeError(".common_proto.collect_list_output.collectedSources: array expected");
+                message.collectedSources = [];
+                for (var i = 0; i < object.collectedSources.length; ++i) {
+                    if (typeof object.collectedSources[i] !== "object")
+                        throw TypeError(".common_proto.collect_list_output.collectedSources: object expected");
+                    message.collectedSources[i] = $root.common_proto.collect_output.fromObject(object.collectedSources[i]);
+                }
+            }
+            if (object.errorSources) {
+                if (!Array.isArray(object.errorSources))
+                    throw TypeError(".common_proto.collect_list_output.errorSources: array expected");
+                message.errorSources = [];
+                for (var i = 0; i < object.errorSources.length; ++i) {
+                    if (typeof object.errorSources[i] !== "object")
+                        throw TypeError(".common_proto.collect_list_output.errorSources: object expected");
+                    message.errorSources[i] = $root.common_proto.collect_error.fromObject(object.errorSources[i]);
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a collect_list_output message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof common_proto.collect_list_output
+         * @static
+         * @param {common_proto.collect_list_output} message collect_list_output
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        collect_list_output.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults) {
+                object.collectedSources = [];
+                object.errorSources = [];
+            }
+            if (message.collectedSources && message.collectedSources.length) {
+                object.collectedSources = [];
+                for (var j = 0; j < message.collectedSources.length; ++j)
+                    object.collectedSources[j] = $root.common_proto.collect_output.toObject(message.collectedSources[j], options);
+            }
+            if (message.errorSources && message.errorSources.length) {
+                object.errorSources = [];
+                for (var j = 0; j < message.errorSources.length; ++j)
+                    object.errorSources[j] = $root.common_proto.collect_error.toObject(message.errorSources[j], options);
+            }
+            return object;
+        };
+
+        /**
+         * Converts this collect_list_output to JSON.
+         * @function toJSON
+         * @memberof common_proto.collect_list_output
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        collect_list_output.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return collect_list_output;
+    })();
+
+    return common_proto;
+})();
+
+$root.alc_health = (function() {
+
+    /**
+     * Namespace alc_health.
+     * @exports alc_health
+     * @namespace
+     */
+    var alc_health = {};
+
+    alc_health.status_update = (function() {
+
+        /**
+         * Properties of a status_update.
+         * @memberof alc_health
+         * @interface Istatus_update
+         * @property {alc_health.status} status status_update status
+         * @property {number|Long} timestamp status_update timestamp
+         * @property {Array.<alc_health.Istatus_update_item>|null} [item] status_update item
+         */
+
+        /**
+         * Constructs a new status_update.
+         * @memberof alc_health
+         * @classdesc Represents a status_update.
+         * @implements Istatus_update
+         * @constructor
+         * @param {alc_health.Istatus_update=} [properties] Properties to set
+         */
+        function status_update(properties) {
+            this.item = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * status_update status.
+         * @member {alc_health.status} status
+         * @memberof alc_health.status_update
+         * @instance
+         */
+        status_update.prototype.status = 0;
+
+        /**
+         * status_update timestamp.
+         * @member {number|Long} timestamp
+         * @memberof alc_health.status_update
+         * @instance
+         */
+        status_update.prototype.timestamp = $util.Long ? $util.Long.fromBits(0,0,true) : 0;
+
+        /**
+         * status_update item.
+         * @member {Array.<alc_health.Istatus_update_item>} item
+         * @memberof alc_health.status_update
+         * @instance
+         */
+        status_update.prototype.item = $util.emptyArray;
+
+        /**
+         * Creates a new status_update instance using the specified properties.
+         * @function create
+         * @memberof alc_health.status_update
+         * @static
+         * @param {alc_health.Istatus_update=} [properties] Properties to set
+         * @returns {alc_health.status_update} status_update instance
+         */
+        status_update.create = function create(properties) {
+            return new status_update(properties);
+        };
+
+        /**
+         * Encodes the specified status_update message. Does not implicitly {@link alc_health.status_update.verify|verify} messages.
+         * @function encode
+         * @memberof alc_health.status_update
+         * @static
+         * @param {alc_health.Istatus_update} message status_update message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        status_update.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            writer.uint32(/* id 1, wireType 0 =*/8).int32(message.status);
+            writer.uint32(/* id 2, wireType 0 =*/16).uint64(message.timestamp);
+            if (message.item != null && message.item.length)
+                for (var i = 0; i < message.item.length; ++i)
+                    $root.alc_health.status_update_item.encode(message.item[i], writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified status_update message, length delimited. Does not implicitly {@link alc_health.status_update.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof alc_health.status_update
+         * @static
+         * @param {alc_health.Istatus_update} message status_update message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        status_update.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a status_update message from the specified reader or buffer.
+         * @function decode
+         * @memberof alc_health.status_update
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {alc_health.status_update} status_update
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        status_update.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.alc_health.status_update();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.status = reader.int32();
+                    break;
+                case 2:
+                    message.timestamp = reader.uint64();
+                    break;
+                case 3:
+                    if (!(message.item && message.item.length))
+                        message.item = [];
+                    message.item.push($root.alc_health.status_update_item.decode(reader, reader.uint32()));
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            if (!message.hasOwnProperty("status"))
+                throw $util.ProtocolError("missing required 'status'", { instance: message });
+            if (!message.hasOwnProperty("timestamp"))
+                throw $util.ProtocolError("missing required 'timestamp'", { instance: message });
+            return message;
+        };
+
+        /**
+         * Decodes a status_update message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof alc_health.status_update
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {alc_health.status_update} status_update
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        status_update.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a status_update message.
+         * @function verify
+         * @memberof alc_health.status_update
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        status_update.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            switch (message.status) {
+            default:
+                return "status: enum value expected";
+            case 0:
+            case 1:
+            case 2:
+            case 3:
+            case 4:
+                break;
+            }
+            if (!$util.isInteger(message.timestamp) && !(message.timestamp && $util.isInteger(message.timestamp.low) && $util.isInteger(message.timestamp.high)))
+                return "timestamp: integer|Long expected";
+            if (message.item != null && message.hasOwnProperty("item")) {
+                if (!Array.isArray(message.item))
+                    return "item: array expected";
+                for (var i = 0; i < message.item.length; ++i) {
+                    var error = $root.alc_health.status_update_item.verify(message.item[i]);
+                    if (error)
+                        return "item." + error;
+                }
+            }
+            return null;
+        };
+
+        /**
+         * Creates a status_update message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof alc_health.status_update
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {alc_health.status_update} status_update
+         */
+        status_update.fromObject = function fromObject(object) {
+            if (object instanceof $root.alc_health.status_update)
+                return object;
+            var message = new $root.alc_health.status_update();
+            switch (object.status) {
+            case "STATUS_OK":
+            case 0:
+                message.status = 0;
+                break;
+            case "STATUS_WARNING":
+            case 1:
+                message.status = 1;
+                break;
+            case "STATUS_ERROR":
+            case 2:
+                message.status = 2;
+                break;
+            case "STATUS_OFFLINE":
+            case 3:
+                message.status = 3;
+                break;
+            case "STATUS_NEW":
+            case 4:
+                message.status = 4;
+                break;
+            }
+            if (object.timestamp != null)
+                if ($util.Long)
+                    (message.timestamp = $util.Long.fromValue(object.timestamp)).unsigned = true;
+                else if (typeof object.timestamp === "string")
+                    message.timestamp = parseInt(object.timestamp, 10);
+                else if (typeof object.timestamp === "number")
+                    message.timestamp = object.timestamp;
+                else if (typeof object.timestamp === "object")
+                    message.timestamp = new $util.LongBits(object.timestamp.low >>> 0, object.timestamp.high >>> 0).toNumber(true);
+            if (object.item) {
+                if (!Array.isArray(object.item))
+                    throw TypeError(".alc_health.status_update.item: array expected");
+                message.item = [];
+                for (var i = 0; i < object.item.length; ++i) {
+                    if (typeof object.item[i] !== "object")
+                        throw TypeError(".alc_health.status_update.item: object expected");
+                    message.item[i] = $root.alc_health.status_update_item.fromObject(object.item[i]);
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a status_update message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof alc_health.status_update
+         * @static
+         * @param {alc_health.status_update} message status_update
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        status_update.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults)
+                object.item = [];
+            if (options.defaults) {
+                object.status = options.enums === String ? "STATUS_OK" : 0;
+                if ($util.Long) {
+                    var long = new $util.Long(0, 0, true);
+                    object.timestamp = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                } else
+                    object.timestamp = options.longs === String ? "0" : 0;
+            }
+            if (message.status != null && message.hasOwnProperty("status"))
+                object.status = options.enums === String ? $root.alc_health.status[message.status] : message.status;
+            if (message.timestamp != null && message.hasOwnProperty("timestamp"))
+                if (typeof message.timestamp === "number")
+                    object.timestamp = options.longs === String ? String(message.timestamp) : message.timestamp;
+                else
+                    object.timestamp = options.longs === String ? $util.Long.prototype.toString.call(message.timestamp) : options.longs === Number ? new $util.LongBits(message.timestamp.low >>> 0, message.timestamp.high >>> 0).toNumber(true) : message.timestamp;
+            if (message.item && message.item.length) {
+                object.item = [];
+                for (var j = 0; j < message.item.length; ++j)
+                    object.item[j] = $root.alc_health.status_update_item.toObject(message.item[j], options);
+            }
+            return object;
+        };
+
+        /**
+         * Converts this status_update to JSON.
+         * @function toJSON
+         * @memberof alc_health.status_update
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        status_update.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return status_update;
+    })();
+
+    /**
+     * status enum.
+     * @name alc_health.status
+     * @enum {string}
+     * @property {number} STATUS_OK=0 STATUS_OK value
+     * @property {number} STATUS_WARNING=1 STATUS_WARNING value
+     * @property {number} STATUS_ERROR=2 STATUS_ERROR value
+     * @property {number} STATUS_OFFLINE=3 STATUS_OFFLINE value
+     * @property {number} STATUS_NEW=4 STATUS_NEW value
+     */
+    alc_health.status = (function() {
+        var valuesById = {}, values = Object.create(valuesById);
+        values[valuesById[0] = "STATUS_OK"] = 0;
+        values[valuesById[1] = "STATUS_WARNING"] = 1;
+        values[valuesById[2] = "STATUS_ERROR"] = 2;
+        values[valuesById[3] = "STATUS_OFFLINE"] = 3;
+        values[valuesById[4] = "STATUS_NEW"] = 4;
+        return values;
+    })();
+
+    alc_health.status_update_item = (function() {
+
+        /**
+         * Properties of a status_update_item.
+         * @memberof alc_health
+         * @interface Istatus_update_item
+         * @property {alc_health.status_update_item_type} type status_update_item type
+         * @property {string} details status_update_item details
+         */
+
+        /**
+         * Constructs a new status_update_item.
+         * @memberof alc_health
+         * @classdesc Represents a status_update_item.
+         * @implements Istatus_update_item
+         * @constructor
+         * @param {alc_health.Istatus_update_item=} [properties] Properties to set
+         */
+        function status_update_item(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * status_update_item type.
+         * @member {alc_health.status_update_item_type} type
+         * @memberof alc_health.status_update_item
+         * @instance
+         */
+        status_update_item.prototype.type = 1;
+
+        /**
+         * status_update_item details.
+         * @member {string} details
+         * @memberof alc_health.status_update_item
+         * @instance
+         */
+        status_update_item.prototype.details = "";
+
+        /**
+         * Creates a new status_update_item instance using the specified properties.
+         * @function create
+         * @memberof alc_health.status_update_item
+         * @static
+         * @param {alc_health.Istatus_update_item=} [properties] Properties to set
+         * @returns {alc_health.status_update_item} status_update_item instance
+         */
+        status_update_item.create = function create(properties) {
+            return new status_update_item(properties);
+        };
+
+        /**
+         * Encodes the specified status_update_item message. Does not implicitly {@link alc_health.status_update_item.verify|verify} messages.
+         * @function encode
+         * @memberof alc_health.status_update_item
+         * @static
+         * @param {alc_health.Istatus_update_item} message status_update_item message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        status_update_item.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            writer.uint32(/* id 1, wireType 0 =*/8).int32(message.type);
+            writer.uint32(/* id 2, wireType 2 =*/18).string(message.details);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified status_update_item message, length delimited. Does not implicitly {@link alc_health.status_update_item.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof alc_health.status_update_item
+         * @static
+         * @param {alc_health.Istatus_update_item} message status_update_item message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        status_update_item.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a status_update_item message from the specified reader or buffer.
+         * @function decode
+         * @memberof alc_health.status_update_item
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {alc_health.status_update_item} status_update_item
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        status_update_item.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.alc_health.status_update_item();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.type = reader.int32();
+                    break;
+                case 2:
+                    message.details = reader.string();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            if (!message.hasOwnProperty("type"))
+                throw $util.ProtocolError("missing required 'type'", { instance: message });
+            if (!message.hasOwnProperty("details"))
+                throw $util.ProtocolError("missing required 'details'", { instance: message });
+            return message;
+        };
+
+        /**
+         * Decodes a status_update_item message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof alc_health.status_update_item
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {alc_health.status_update_item} status_update_item
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        status_update_item.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a status_update_item message.
+         * @function verify
+         * @memberof alc_health.status_update_item
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        status_update_item.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            switch (message.type) {
+            default:
+                return "type: enum value expected";
+            case 1:
+            case 2:
+            case 3:
+                break;
+            }
+            if (!$util.isString(message.details))
+                return "details: string expected";
+            return null;
+        };
+
+        /**
+         * Creates a status_update_item message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof alc_health.status_update_item
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {alc_health.status_update_item} status_update_item
+         */
+        status_update_item.fromObject = function fromObject(object) {
+            if (object instanceof $root.alc_health.status_update_item)
+                return object;
+            var message = new $root.alc_health.status_update_item();
+            switch (object.type) {
+            case "ERROR_UPDATE":
+            case 1:
+                message.type = 1;
+                break;
+            case "WARNING_UPDATE":
+            case 2:
+                message.type = 2;
+                break;
+            case "INFO_UPDATE":
+            case 3:
+                message.type = 3;
+                break;
+            }
+            if (object.details != null)
+                message.details = String(object.details);
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a status_update_item message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof alc_health.status_update_item
+         * @static
+         * @param {alc_health.status_update_item} message status_update_item
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        status_update_item.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.type = options.enums === String ? "ERROR_UPDATE" : 1;
+                object.details = "";
+            }
+            if (message.type != null && message.hasOwnProperty("type"))
+                object.type = options.enums === String ? $root.alc_health.status_update_item_type[message.type] : message.type;
+            if (message.details != null && message.hasOwnProperty("details"))
+                object.details = message.details;
+            return object;
+        };
+
+        /**
+         * Converts this status_update_item to JSON.
+         * @function toJSON
+         * @memberof alc_health.status_update_item
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        status_update_item.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return status_update_item;
+    })();
+
+    /**
+     * status_update_item_type enum.
+     * @name alc_health.status_update_item_type
+     * @enum {string}
+     * @property {number} ERROR_UPDATE=1 ERROR_UPDATE value
+     * @property {number} WARNING_UPDATE=2 WARNING_UPDATE value
+     * @property {number} INFO_UPDATE=3 INFO_UPDATE value
+     */
+    alc_health.status_update_item_type = (function() {
+        var valuesById = {}, values = Object.create(valuesById);
+        values[valuesById[1] = "ERROR_UPDATE"] = 1;
+        values[valuesById[2] = "WARNING_UPDATE"] = 2;
+        values[valuesById[3] = "INFO_UPDATE"] = 3;
+        return values;
+    })();
+
+    return alc_health;
+})();
+
+$root.host_metadata = (function() {
+
+    /**
+     * Namespace host_metadata.
+     * @exports host_metadata
+     * @namespace
+     */
+    var host_metadata = {};
+
+    host_metadata.metadata = (function() {
+
+        /**
+         * Properties of a metadata.
+         * @memberof host_metadata
+         * @interface Imetadata
+         * @property {string|null} [hostUuid] metadata hostUuid
+         * @property {Uint8Array} dataChecksum metadata dataChecksum
+         * @property {number|Long|null} [timestamp] metadata timestamp
+         * @property {alc_dict.Idict|null} [data] metadata data
+         */
+
+        /**
+         * Constructs a new metadata.
+         * @memberof host_metadata
+         * @classdesc Represents a metadata.
+         * @implements Imetadata
+         * @constructor
+         * @param {host_metadata.Imetadata=} [properties] Properties to set
+         */
+        function metadata(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * metadata hostUuid.
+         * @member {string} hostUuid
+         * @memberof host_metadata.metadata
+         * @instance
+         */
+        metadata.prototype.hostUuid = "";
+
+        /**
+         * metadata dataChecksum.
+         * @member {Uint8Array} dataChecksum
+         * @memberof host_metadata.metadata
+         * @instance
+         */
+        metadata.prototype.dataChecksum = $util.newBuffer([]);
+
+        /**
+         * metadata timestamp.
+         * @member {number|Long} timestamp
+         * @memberof host_metadata.metadata
+         * @instance
+         */
+        metadata.prototype.timestamp = $util.Long ? $util.Long.fromBits(0,0,true) : 0;
+
+        /**
+         * metadata data.
+         * @member {alc_dict.Idict|null|undefined} data
+         * @memberof host_metadata.metadata
+         * @instance
+         */
+        metadata.prototype.data = null;
+
+        /**
+         * Creates a new metadata instance using the specified properties.
+         * @function create
+         * @memberof host_metadata.metadata
+         * @static
+         * @param {host_metadata.Imetadata=} [properties] Properties to set
+         * @returns {host_metadata.metadata} metadata instance
+         */
+        metadata.create = function create(properties) {
+            return new metadata(properties);
+        };
+
+        /**
+         * Encodes the specified metadata message. Does not implicitly {@link host_metadata.metadata.verify|verify} messages.
+         * @function encode
+         * @memberof host_metadata.metadata
+         * @static
+         * @param {host_metadata.Imetadata} message metadata message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        metadata.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.hostUuid != null && message.hasOwnProperty("hostUuid"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.hostUuid);
+            writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.dataChecksum);
+            if (message.timestamp != null && message.hasOwnProperty("timestamp"))
+                writer.uint32(/* id 3, wireType 0 =*/24).uint64(message.timestamp);
+            if (message.data != null && message.hasOwnProperty("data"))
+                $root.alc_dict.dict.encode(message.data, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified metadata message, length delimited. Does not implicitly {@link host_metadata.metadata.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof host_metadata.metadata
+         * @static
+         * @param {host_metadata.Imetadata} message metadata message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        metadata.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a metadata message from the specified reader or buffer.
+         * @function decode
+         * @memberof host_metadata.metadata
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {host_metadata.metadata} metadata
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        metadata.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.host_metadata.metadata();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.hostUuid = reader.string();
+                    break;
+                case 2:
+                    message.dataChecksum = reader.bytes();
+                    break;
+                case 3:
+                    message.timestamp = reader.uint64();
+                    break;
+                case 4:
+                    message.data = $root.alc_dict.dict.decode(reader, reader.uint32());
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            if (!message.hasOwnProperty("dataChecksum"))
+                throw $util.ProtocolError("missing required 'dataChecksum'", { instance: message });
+            return message;
+        };
+
+        /**
+         * Decodes a metadata message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof host_metadata.metadata
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {host_metadata.metadata} metadata
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        metadata.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a metadata message.
+         * @function verify
+         * @memberof host_metadata.metadata
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        metadata.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.hostUuid != null && message.hasOwnProperty("hostUuid"))
+                if (!$util.isString(message.hostUuid))
+                    return "hostUuid: string expected";
+            if (!(message.dataChecksum && typeof message.dataChecksum.length === "number" || $util.isString(message.dataChecksum)))
+                return "dataChecksum: buffer expected";
+            if (message.timestamp != null && message.hasOwnProperty("timestamp"))
+                if (!$util.isInteger(message.timestamp) && !(message.timestamp && $util.isInteger(message.timestamp.low) && $util.isInteger(message.timestamp.high)))
+                    return "timestamp: integer|Long expected";
+            if (message.data != null && message.hasOwnProperty("data")) {
+                var error = $root.alc_dict.dict.verify(message.data);
+                if (error)
+                    return "data." + error;
+            }
+            return null;
+        };
+
+        /**
+         * Creates a metadata message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof host_metadata.metadata
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {host_metadata.metadata} metadata
+         */
+        metadata.fromObject = function fromObject(object) {
+            if (object instanceof $root.host_metadata.metadata)
+                return object;
+            var message = new $root.host_metadata.metadata();
+            if (object.hostUuid != null)
+                message.hostUuid = String(object.hostUuid);
+            if (object.dataChecksum != null)
+                if (typeof object.dataChecksum === "string")
+                    $util.base64.decode(object.dataChecksum, message.dataChecksum = $util.newBuffer($util.base64.length(object.dataChecksum)), 0);
+                else if (object.dataChecksum.length)
+                    message.dataChecksum = object.dataChecksum;
+            if (object.timestamp != null)
+                if ($util.Long)
+                    (message.timestamp = $util.Long.fromValue(object.timestamp)).unsigned = true;
+                else if (typeof object.timestamp === "string")
+                    message.timestamp = parseInt(object.timestamp, 10);
+                else if (typeof object.timestamp === "number")
+                    message.timestamp = object.timestamp;
+                else if (typeof object.timestamp === "object")
+                    message.timestamp = new $util.LongBits(object.timestamp.low >>> 0, object.timestamp.high >>> 0).toNumber(true);
+            if (object.data != null) {
+                if (typeof object.data !== "object")
+                    throw TypeError(".host_metadata.metadata.data: object expected");
+                message.data = $root.alc_dict.dict.fromObject(object.data);
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a metadata message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof host_metadata.metadata
+         * @static
+         * @param {host_metadata.metadata} message metadata
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        metadata.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.hostUuid = "";
+                if (options.bytes === String)
+                    object.dataChecksum = "";
+                else {
+                    object.dataChecksum = [];
+                    if (options.bytes !== Array)
+                        object.dataChecksum = $util.newBuffer(object.dataChecksum);
+                }
+                if ($util.Long) {
+                    var long = new $util.Long(0, 0, true);
+                    object.timestamp = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                } else
+                    object.timestamp = options.longs === String ? "0" : 0;
+                object.data = null;
+            }
+            if (message.hostUuid != null && message.hasOwnProperty("hostUuid"))
+                object.hostUuid = message.hostUuid;
+            if (message.dataChecksum != null && message.hasOwnProperty("dataChecksum"))
+                object.dataChecksum = options.bytes === String ? $util.base64.encode(message.dataChecksum, 0, message.dataChecksum.length) : options.bytes === Array ? Array.prototype.slice.call(message.dataChecksum) : message.dataChecksum;
+            if (message.timestamp != null && message.hasOwnProperty("timestamp"))
+                if (typeof message.timestamp === "number")
+                    object.timestamp = options.longs === String ? String(message.timestamp) : message.timestamp;
+                else
+                    object.timestamp = options.longs === String ? $util.Long.prototype.toString.call(message.timestamp) : options.longs === Number ? new $util.LongBits(message.timestamp.low >>> 0, message.timestamp.high >>> 0).toNumber(true) : message.timestamp;
+            if (message.data != null && message.hasOwnProperty("data"))
+                object.data = $root.alc_dict.dict.toObject(message.data, options);
+            return object;
+        };
+
+        /**
+         * Converts this metadata to JSON.
+         * @function toJSON
+         * @memberof host_metadata.metadata
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        metadata.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return metadata;
+    })();
+
+    return host_metadata;
+})();
+
+$root.alc_dict = (function() {
+
+    /**
+     * Namespace alc_dict.
+     * @exports alc_dict
+     * @namespace
+     */
+    var alc_dict = {};
+
+    alc_dict.dict = (function() {
+
+        /**
+         * Properties of a dict.
+         * @memberof alc_dict
+         * @interface Idict
+         * @property {Array.<alc_dict.Ielem>|null} [elem] dict elem
+         */
+
+        /**
+         * Constructs a new dict.
+         * @memberof alc_dict
+         * @classdesc Represents a dict.
+         * @implements Idict
+         * @constructor
+         * @param {alc_dict.Idict=} [properties] Properties to set
+         */
+        function dict(properties) {
+            this.elem = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * dict elem.
+         * @member {Array.<alc_dict.Ielem>} elem
+         * @memberof alc_dict.dict
+         * @instance
+         */
+        dict.prototype.elem = $util.emptyArray;
+
+        /**
+         * Creates a new dict instance using the specified properties.
+         * @function create
+         * @memberof alc_dict.dict
+         * @static
+         * @param {alc_dict.Idict=} [properties] Properties to set
+         * @returns {alc_dict.dict} dict instance
+         */
+        dict.create = function create(properties) {
+            return new dict(properties);
+        };
+
+        /**
+         * Encodes the specified dict message. Does not implicitly {@link alc_dict.dict.verify|verify} messages.
+         * @function encode
+         * @memberof alc_dict.dict
+         * @static
+         * @param {alc_dict.Idict} message dict message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        dict.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.elem != null && message.elem.length)
+                for (var i = 0; i < message.elem.length; ++i)
+                    $root.alc_dict.elem.encode(message.elem[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified dict message, length delimited. Does not implicitly {@link alc_dict.dict.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof alc_dict.dict
+         * @static
+         * @param {alc_dict.Idict} message dict message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        dict.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a dict message from the specified reader or buffer.
+         * @function decode
+         * @memberof alc_dict.dict
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {alc_dict.dict} dict
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        dict.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.alc_dict.dict();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    if (!(message.elem && message.elem.length))
+                        message.elem = [];
+                    message.elem.push($root.alc_dict.elem.decode(reader, reader.uint32()));
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a dict message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof alc_dict.dict
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {alc_dict.dict} dict
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        dict.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a dict message.
+         * @function verify
+         * @memberof alc_dict.dict
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        dict.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.elem != null && message.hasOwnProperty("elem")) {
+                if (!Array.isArray(message.elem))
+                    return "elem: array expected";
+                for (var i = 0; i < message.elem.length; ++i) {
+                    var error = $root.alc_dict.elem.verify(message.elem[i]);
+                    if (error)
+                        return "elem." + error;
+                }
+            }
+            return null;
+        };
+
+        /**
+         * Creates a dict message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof alc_dict.dict
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {alc_dict.dict} dict
+         */
+        dict.fromObject = function fromObject(object) {
+            if (object instanceof $root.alc_dict.dict)
+                return object;
+            var message = new $root.alc_dict.dict();
+            if (object.elem) {
+                if (!Array.isArray(object.elem))
+                    throw TypeError(".alc_dict.dict.elem: array expected");
+                message.elem = [];
+                for (var i = 0; i < object.elem.length; ++i) {
+                    if (typeof object.elem[i] !== "object")
+                        throw TypeError(".alc_dict.dict.elem: object expected");
+                    message.elem[i] = $root.alc_dict.elem.fromObject(object.elem[i]);
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a dict message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof alc_dict.dict
+         * @static
+         * @param {alc_dict.dict} message dict
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        dict.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults)
+                object.elem = [];
+            if (message.elem && message.elem.length) {
+                object.elem = [];
+                for (var j = 0; j < message.elem.length; ++j)
+                    object.elem[j] = $root.alc_dict.elem.toObject(message.elem[j], options);
+            }
+            return object;
+        };
+
+        /**
+         * Converts this dict to JSON.
+         * @function toJSON
+         * @memberof alc_dict.dict
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        dict.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return dict;
+    })();
+
+    alc_dict.elem = (function() {
+
+        /**
+         * Properties of an elem.
+         * @memberof alc_dict
+         * @interface Ielem
+         * @property {string} key elem key
+         * @property {alc_dict.Ivalue|null} [value] elem value
+         */
+
+        /**
+         * Constructs a new elem.
+         * @memberof alc_dict
+         * @classdesc Represents an elem.
+         * @implements Ielem
+         * @constructor
+         * @param {alc_dict.Ielem=} [properties] Properties to set
+         */
+        function elem(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * elem key.
+         * @member {string} key
+         * @memberof alc_dict.elem
+         * @instance
+         */
+        elem.prototype.key = "";
+
+        /**
+         * elem value.
+         * @member {alc_dict.Ivalue|null|undefined} value
+         * @memberof alc_dict.elem
+         * @instance
+         */
+        elem.prototype.value = null;
+
+        /**
+         * Creates a new elem instance using the specified properties.
+         * @function create
+         * @memberof alc_dict.elem
+         * @static
+         * @param {alc_dict.Ielem=} [properties] Properties to set
+         * @returns {alc_dict.elem} elem instance
+         */
+        elem.create = function create(properties) {
+            return new elem(properties);
+        };
+
+        /**
+         * Encodes the specified elem message. Does not implicitly {@link alc_dict.elem.verify|verify} messages.
+         * @function encode
+         * @memberof alc_dict.elem
+         * @static
+         * @param {alc_dict.Ielem} message elem message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        elem.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            writer.uint32(/* id 1, wireType 2 =*/10).string(message.key);
+            if (message.value != null && message.hasOwnProperty("value"))
+                $root.alc_dict.value.encode(message.value, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified elem message, length delimited. Does not implicitly {@link alc_dict.elem.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof alc_dict.elem
+         * @static
+         * @param {alc_dict.Ielem} message elem message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        elem.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes an elem message from the specified reader or buffer.
+         * @function decode
+         * @memberof alc_dict.elem
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {alc_dict.elem} elem
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        elem.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.alc_dict.elem();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.key = reader.string();
+                    break;
+                case 2:
+                    message.value = $root.alc_dict.value.decode(reader, reader.uint32());
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            if (!message.hasOwnProperty("key"))
+                throw $util.ProtocolError("missing required 'key'", { instance: message });
+            return message;
+        };
+
+        /**
+         * Decodes an elem message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof alc_dict.elem
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {alc_dict.elem} elem
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        elem.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies an elem message.
+         * @function verify
+         * @memberof alc_dict.elem
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        elem.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (!$util.isString(message.key))
+                return "key: string expected";
+            if (message.value != null && message.hasOwnProperty("value")) {
+                var error = $root.alc_dict.value.verify(message.value);
+                if (error)
+                    return "value." + error;
+            }
+            return null;
+        };
+
+        /**
+         * Creates an elem message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof alc_dict.elem
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {alc_dict.elem} elem
+         */
+        elem.fromObject = function fromObject(object) {
+            if (object instanceof $root.alc_dict.elem)
+                return object;
+            var message = new $root.alc_dict.elem();
+            if (object.key != null)
+                message.key = String(object.key);
+            if (object.value != null) {
+                if (typeof object.value !== "object")
+                    throw TypeError(".alc_dict.elem.value: object expected");
+                message.value = $root.alc_dict.value.fromObject(object.value);
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from an elem message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof alc_dict.elem
+         * @static
+         * @param {alc_dict.elem} message elem
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        elem.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.key = "";
+                object.value = null;
+            }
+            if (message.key != null && message.hasOwnProperty("key"))
+                object.key = message.key;
+            if (message.value != null && message.hasOwnProperty("value"))
+                object.value = $root.alc_dict.value.toObject(message.value, options);
+            return object;
+        };
+
+        /**
+         * Converts this elem to JSON.
+         * @function toJSON
+         * @memberof alc_dict.elem
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        elem.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return elem;
+    })();
+
+    alc_dict.value = (function() {
+
+        /**
+         * Properties of a value.
+         * @memberof alc_dict
+         * @interface Ivalue
+         * @property {alc_dict.Idict|null} [dict] value dict
+         * @property {alc_dict.Ilist|null} [list] value list
+         * @property {string|null} [str] value str
+         * @property {boolean|null} [b] value b
+         * @property {number|null} [i] value i
+         */
+
+        /**
+         * Constructs a new value.
+         * @memberof alc_dict
+         * @classdesc Represents a value.
+         * @implements Ivalue
+         * @constructor
+         * @param {alc_dict.Ivalue=} [properties] Properties to set
+         */
+        function value(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * value dict.
+         * @member {alc_dict.Idict|null|undefined} dict
+         * @memberof alc_dict.value
+         * @instance
+         */
+        value.prototype.dict = null;
+
+        /**
+         * value list.
+         * @member {alc_dict.Ilist|null|undefined} list
+         * @memberof alc_dict.value
+         * @instance
+         */
+        value.prototype.list = null;
+
+        /**
+         * value str.
+         * @member {string} str
+         * @memberof alc_dict.value
+         * @instance
+         */
+        value.prototype.str = "";
+
+        /**
+         * value b.
+         * @member {boolean} b
+         * @memberof alc_dict.value
+         * @instance
+         */
+        value.prototype.b = false;
+
+        /**
+         * value i.
+         * @member {number} i
+         * @memberof alc_dict.value
+         * @instance
+         */
+        value.prototype.i = 0;
+
+        /**
+         * Creates a new value instance using the specified properties.
+         * @function create
+         * @memberof alc_dict.value
+         * @static
+         * @param {alc_dict.Ivalue=} [properties] Properties to set
+         * @returns {alc_dict.value} value instance
+         */
+        value.create = function create(properties) {
+            return new value(properties);
+        };
+
+        /**
+         * Encodes the specified value message. Does not implicitly {@link alc_dict.value.verify|verify} messages.
+         * @function encode
+         * @memberof alc_dict.value
+         * @static
+         * @param {alc_dict.Ivalue} message value message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        value.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.dict != null && message.hasOwnProperty("dict"))
+                $root.alc_dict.dict.encode(message.dict, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            if (message.list != null && message.hasOwnProperty("list"))
+                $root.alc_dict.list.encode(message.list, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            if (message.str != null && message.hasOwnProperty("str"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.str);
+            if (message.b != null && message.hasOwnProperty("b"))
+                writer.uint32(/* id 4, wireType 0 =*/32).bool(message.b);
+            if (message.i != null && message.hasOwnProperty("i"))
+                writer.uint32(/* id 5, wireType 0 =*/40).sint32(message.i);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified value message, length delimited. Does not implicitly {@link alc_dict.value.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof alc_dict.value
+         * @static
+         * @param {alc_dict.Ivalue} message value message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        value.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a value message from the specified reader or buffer.
+         * @function decode
+         * @memberof alc_dict.value
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {alc_dict.value} value
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        value.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.alc_dict.value();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.dict = $root.alc_dict.dict.decode(reader, reader.uint32());
+                    break;
+                case 2:
+                    message.list = $root.alc_dict.list.decode(reader, reader.uint32());
+                    break;
+                case 3:
+                    message.str = reader.string();
+                    break;
+                case 4:
+                    message.b = reader.bool();
+                    break;
+                case 5:
+                    message.i = reader.sint32();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a value message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof alc_dict.value
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {alc_dict.value} value
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        value.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a value message.
+         * @function verify
+         * @memberof alc_dict.value
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        value.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.dict != null && message.hasOwnProperty("dict")) {
+                var error = $root.alc_dict.dict.verify(message.dict);
+                if (error)
+                    return "dict." + error;
+            }
+            if (message.list != null && message.hasOwnProperty("list")) {
+                var error = $root.alc_dict.list.verify(message.list);
+                if (error)
+                    return "list." + error;
+            }
+            if (message.str != null && message.hasOwnProperty("str"))
+                if (!$util.isString(message.str))
+                    return "str: string expected";
+            if (message.b != null && message.hasOwnProperty("b"))
+                if (typeof message.b !== "boolean")
+                    return "b: boolean expected";
+            if (message.i != null && message.hasOwnProperty("i"))
+                if (!$util.isInteger(message.i))
+                    return "i: integer expected";
+            return null;
+        };
+
+        /**
+         * Creates a value message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof alc_dict.value
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {alc_dict.value} value
+         */
+        value.fromObject = function fromObject(object) {
+            if (object instanceof $root.alc_dict.value)
+                return object;
+            var message = new $root.alc_dict.value();
+            if (object.dict != null) {
+                if (typeof object.dict !== "object")
+                    throw TypeError(".alc_dict.value.dict: object expected");
+                message.dict = $root.alc_dict.dict.fromObject(object.dict);
+            }
+            if (object.list != null) {
+                if (typeof object.list !== "object")
+                    throw TypeError(".alc_dict.value.list: object expected");
+                message.list = $root.alc_dict.list.fromObject(object.list);
+            }
+            if (object.str != null)
+                message.str = String(object.str);
+            if (object.b != null)
+                message.b = Boolean(object.b);
+            if (object.i != null)
+                message.i = object.i | 0;
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a value message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof alc_dict.value
+         * @static
+         * @param {alc_dict.value} message value
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        value.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.dict = null;
+                object.list = null;
+                object.str = "";
+                object.b = false;
+                object.i = 0;
+            }
+            if (message.dict != null && message.hasOwnProperty("dict"))
+                object.dict = $root.alc_dict.dict.toObject(message.dict, options);
+            if (message.list != null && message.hasOwnProperty("list"))
+                object.list = $root.alc_dict.list.toObject(message.list, options);
+            if (message.str != null && message.hasOwnProperty("str"))
+                object.str = message.str;
+            if (message.b != null && message.hasOwnProperty("b"))
+                object.b = message.b;
+            if (message.i != null && message.hasOwnProperty("i"))
+                object.i = message.i;
+            return object;
+        };
+
+        /**
+         * Converts this value to JSON.
+         * @function toJSON
+         * @memberof alc_dict.value
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        value.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return value;
+    })();
+
+    alc_dict.list = (function() {
+
+        /**
+         * Properties of a list.
+         * @memberof alc_dict
+         * @interface Ilist
+         * @property {Array.<alc_dict.Ivalue>|null} [elem] list elem
+         */
+
+        /**
+         * Constructs a new list.
+         * @memberof alc_dict
+         * @classdesc Represents a list.
+         * @implements Ilist
+         * @constructor
+         * @param {alc_dict.Ilist=} [properties] Properties to set
+         */
+        function list(properties) {
+            this.elem = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * list elem.
+         * @member {Array.<alc_dict.Ivalue>} elem
+         * @memberof alc_dict.list
+         * @instance
+         */
+        list.prototype.elem = $util.emptyArray;
+
+        /**
+         * Creates a new list instance using the specified properties.
+         * @function create
+         * @memberof alc_dict.list
+         * @static
+         * @param {alc_dict.Ilist=} [properties] Properties to set
+         * @returns {alc_dict.list} list instance
+         */
+        list.create = function create(properties) {
+            return new list(properties);
+        };
+
+        /**
+         * Encodes the specified list message. Does not implicitly {@link alc_dict.list.verify|verify} messages.
+         * @function encode
+         * @memberof alc_dict.list
+         * @static
+         * @param {alc_dict.Ilist} message list message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        list.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.elem != null && message.elem.length)
+                for (var i = 0; i < message.elem.length; ++i)
+                    $root.alc_dict.value.encode(message.elem[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified list message, length delimited. Does not implicitly {@link alc_dict.list.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof alc_dict.list
+         * @static
+         * @param {alc_dict.Ilist} message list message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        list.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a list message from the specified reader or buffer.
+         * @function decode
+         * @memberof alc_dict.list
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {alc_dict.list} list
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        list.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.alc_dict.list();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    if (!(message.elem && message.elem.length))
+                        message.elem = [];
+                    message.elem.push($root.alc_dict.value.decode(reader, reader.uint32()));
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a list message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof alc_dict.list
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {alc_dict.list} list
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        list.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a list message.
+         * @function verify
+         * @memberof alc_dict.list
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        list.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.elem != null && message.hasOwnProperty("elem")) {
+                if (!Array.isArray(message.elem))
+                    return "elem: array expected";
+                for (var i = 0; i < message.elem.length; ++i) {
+                    var error = $root.alc_dict.value.verify(message.elem[i]);
+                    if (error)
+                        return "elem." + error;
+                }
+            }
+            return null;
+        };
+
+        /**
+         * Creates a list message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof alc_dict.list
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {alc_dict.list} list
+         */
+        list.fromObject = function fromObject(object) {
+            if (object instanceof $root.alc_dict.list)
+                return object;
+            var message = new $root.alc_dict.list();
+            if (object.elem) {
+                if (!Array.isArray(object.elem))
+                    throw TypeError(".alc_dict.list.elem: array expected");
+                message.elem = [];
+                for (var i = 0; i < object.elem.length; ++i) {
+                    if (typeof object.elem[i] !== "object")
+                        throw TypeError(".alc_dict.list.elem: object expected");
+                    message.elem[i] = $root.alc_dict.value.fromObject(object.elem[i]);
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a list message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof alc_dict.list
+         * @static
+         * @param {alc_dict.list} message list
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        list.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults)
+                object.elem = [];
+            if (message.elem && message.elem.length) {
+                object.elem = [];
+                for (var j = 0; j < message.elem.length; ++j)
+                    object.elem[j] = $root.alc_dict.value.toObject(message.elem[j], options);
+            }
+            return object;
+        };
+
+        /**
+         * Converts this list to JSON.
+         * @function toJSON
+         * @memberof alc_dict.list
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        list.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return list;
+    })();
+
+    return alc_dict;
+})();
+
+module.exports = $root;

--- a/proto/dict.piqi.proto
+++ b/proto/dict.piqi.proto
@@ -1,0 +1,24 @@
+package alc_dict;
+
+
+message dict {
+    repeated elem elem = 1;
+}
+
+message elem {
+    required string key = 1;
+    optional value value = 2;
+}
+
+message value {
+    optional dict dict = 1;
+    optional list list = 2;
+    optional string str = 3;
+    optional bool b = 4;
+    optional sint32 i = 5;
+}
+
+message list {
+    repeated value elem = 1;
+}
+

--- a/proto/dict.piqi_pb.js
+++ b/proto/dict.piqi_pb.js
@@ -1,0 +1,941 @@
+/*eslint-disable block-scoped-var, id-length, no-control-regex, no-magic-numbers, no-prototype-builtins, no-redeclare, no-shadow, no-var, sort-vars*/
+"use strict";
+
+var $protobuf = require("protobufjs/minimal");
+
+// Common aliases
+var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
+
+// Exported root namespace
+var $root = $protobuf.roots["default"] || ($protobuf.roots["default"] = {});
+
+$root.alc_dict = (function() {
+
+    /**
+     * Namespace alc_dict.
+     * @exports alc_dict
+     * @namespace
+     */
+    var alc_dict = {};
+
+    alc_dict.dict = (function() {
+
+        /**
+         * Properties of a dict.
+         * @memberof alc_dict
+         * @interface Idict
+         * @property {Array.<alc_dict.Ielem>|null} [elem] dict elem
+         */
+
+        /**
+         * Constructs a new dict.
+         * @memberof alc_dict
+         * @classdesc Represents a dict.
+         * @implements Idict
+         * @constructor
+         * @param {alc_dict.Idict=} [properties] Properties to set
+         */
+        function dict(properties) {
+            this.elem = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * dict elem.
+         * @member {Array.<alc_dict.Ielem>} elem
+         * @memberof alc_dict.dict
+         * @instance
+         */
+        dict.prototype.elem = $util.emptyArray;
+
+        /**
+         * Creates a new dict instance using the specified properties.
+         * @function create
+         * @memberof alc_dict.dict
+         * @static
+         * @param {alc_dict.Idict=} [properties] Properties to set
+         * @returns {alc_dict.dict} dict instance
+         */
+        dict.create = function create(properties) {
+            return new dict(properties);
+        };
+
+        /**
+         * Encodes the specified dict message. Does not implicitly {@link alc_dict.dict.verify|verify} messages.
+         * @function encode
+         * @memberof alc_dict.dict
+         * @static
+         * @param {alc_dict.Idict} message dict message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        dict.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.elem != null && message.elem.length)
+                for (var i = 0; i < message.elem.length; ++i)
+                    $root.alc_dict.elem.encode(message.elem[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified dict message, length delimited. Does not implicitly {@link alc_dict.dict.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof alc_dict.dict
+         * @static
+         * @param {alc_dict.Idict} message dict message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        dict.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a dict message from the specified reader or buffer.
+         * @function decode
+         * @memberof alc_dict.dict
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {alc_dict.dict} dict
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        dict.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.alc_dict.dict();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    if (!(message.elem && message.elem.length))
+                        message.elem = [];
+                    message.elem.push($root.alc_dict.elem.decode(reader, reader.uint32()));
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a dict message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof alc_dict.dict
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {alc_dict.dict} dict
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        dict.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a dict message.
+         * @function verify
+         * @memberof alc_dict.dict
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        dict.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.elem != null && message.hasOwnProperty("elem")) {
+                if (!Array.isArray(message.elem))
+                    return "elem: array expected";
+                for (var i = 0; i < message.elem.length; ++i) {
+                    var error = $root.alc_dict.elem.verify(message.elem[i]);
+                    if (error)
+                        return "elem." + error;
+                }
+            }
+            return null;
+        };
+
+        /**
+         * Creates a dict message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof alc_dict.dict
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {alc_dict.dict} dict
+         */
+        dict.fromObject = function fromObject(object) {
+            if (object instanceof $root.alc_dict.dict)
+                return object;
+            var message = new $root.alc_dict.dict();
+            if (object.elem) {
+                if (!Array.isArray(object.elem))
+                    throw TypeError(".alc_dict.dict.elem: array expected");
+                message.elem = [];
+                for (var i = 0; i < object.elem.length; ++i) {
+                    if (typeof object.elem[i] !== "object")
+                        throw TypeError(".alc_dict.dict.elem: object expected");
+                    message.elem[i] = $root.alc_dict.elem.fromObject(object.elem[i]);
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a dict message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof alc_dict.dict
+         * @static
+         * @param {alc_dict.dict} message dict
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        dict.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults)
+                object.elem = [];
+            if (message.elem && message.elem.length) {
+                object.elem = [];
+                for (var j = 0; j < message.elem.length; ++j)
+                    object.elem[j] = $root.alc_dict.elem.toObject(message.elem[j], options);
+            }
+            return object;
+        };
+
+        /**
+         * Converts this dict to JSON.
+         * @function toJSON
+         * @memberof alc_dict.dict
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        dict.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return dict;
+    })();
+
+    alc_dict.elem = (function() {
+
+        /**
+         * Properties of an elem.
+         * @memberof alc_dict
+         * @interface Ielem
+         * @property {string} key elem key
+         * @property {alc_dict.Ivalue|null} [value] elem value
+         */
+
+        /**
+         * Constructs a new elem.
+         * @memberof alc_dict
+         * @classdesc Represents an elem.
+         * @implements Ielem
+         * @constructor
+         * @param {alc_dict.Ielem=} [properties] Properties to set
+         */
+        function elem(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * elem key.
+         * @member {string} key
+         * @memberof alc_dict.elem
+         * @instance
+         */
+        elem.prototype.key = "";
+
+        /**
+         * elem value.
+         * @member {alc_dict.Ivalue|null|undefined} value
+         * @memberof alc_dict.elem
+         * @instance
+         */
+        elem.prototype.value = null;
+
+        /**
+         * Creates a new elem instance using the specified properties.
+         * @function create
+         * @memberof alc_dict.elem
+         * @static
+         * @param {alc_dict.Ielem=} [properties] Properties to set
+         * @returns {alc_dict.elem} elem instance
+         */
+        elem.create = function create(properties) {
+            return new elem(properties);
+        };
+
+        /**
+         * Encodes the specified elem message. Does not implicitly {@link alc_dict.elem.verify|verify} messages.
+         * @function encode
+         * @memberof alc_dict.elem
+         * @static
+         * @param {alc_dict.Ielem} message elem message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        elem.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            writer.uint32(/* id 1, wireType 2 =*/10).string(message.key);
+            if (message.value != null && message.hasOwnProperty("value"))
+                $root.alc_dict.value.encode(message.value, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified elem message, length delimited. Does not implicitly {@link alc_dict.elem.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof alc_dict.elem
+         * @static
+         * @param {alc_dict.Ielem} message elem message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        elem.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes an elem message from the specified reader or buffer.
+         * @function decode
+         * @memberof alc_dict.elem
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {alc_dict.elem} elem
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        elem.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.alc_dict.elem();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.key = reader.string();
+                    break;
+                case 2:
+                    message.value = $root.alc_dict.value.decode(reader, reader.uint32());
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            if (!message.hasOwnProperty("key"))
+                throw $util.ProtocolError("missing required 'key'", { instance: message });
+            return message;
+        };
+
+        /**
+         * Decodes an elem message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof alc_dict.elem
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {alc_dict.elem} elem
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        elem.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies an elem message.
+         * @function verify
+         * @memberof alc_dict.elem
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        elem.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (!$util.isString(message.key))
+                return "key: string expected";
+            if (message.value != null && message.hasOwnProperty("value")) {
+                var error = $root.alc_dict.value.verify(message.value);
+                if (error)
+                    return "value." + error;
+            }
+            return null;
+        };
+
+        /**
+         * Creates an elem message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof alc_dict.elem
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {alc_dict.elem} elem
+         */
+        elem.fromObject = function fromObject(object) {
+            if (object instanceof $root.alc_dict.elem)
+                return object;
+            var message = new $root.alc_dict.elem();
+            if (object.key != null)
+                message.key = String(object.key);
+            if (object.value != null) {
+                if (typeof object.value !== "object")
+                    throw TypeError(".alc_dict.elem.value: object expected");
+                message.value = $root.alc_dict.value.fromObject(object.value);
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from an elem message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof alc_dict.elem
+         * @static
+         * @param {alc_dict.elem} message elem
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        elem.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.key = "";
+                object.value = null;
+            }
+            if (message.key != null && message.hasOwnProperty("key"))
+                object.key = message.key;
+            if (message.value != null && message.hasOwnProperty("value"))
+                object.value = $root.alc_dict.value.toObject(message.value, options);
+            return object;
+        };
+
+        /**
+         * Converts this elem to JSON.
+         * @function toJSON
+         * @memberof alc_dict.elem
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        elem.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return elem;
+    })();
+
+    alc_dict.value = (function() {
+
+        /**
+         * Properties of a value.
+         * @memberof alc_dict
+         * @interface Ivalue
+         * @property {alc_dict.Idict|null} [dict] value dict
+         * @property {alc_dict.Ilist|null} [list] value list
+         * @property {string|null} [str] value str
+         * @property {boolean|null} [b] value b
+         * @property {number|null} [i] value i
+         */
+
+        /**
+         * Constructs a new value.
+         * @memberof alc_dict
+         * @classdesc Represents a value.
+         * @implements Ivalue
+         * @constructor
+         * @param {alc_dict.Ivalue=} [properties] Properties to set
+         */
+        function value(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * value dict.
+         * @member {alc_dict.Idict|null|undefined} dict
+         * @memberof alc_dict.value
+         * @instance
+         */
+        value.prototype.dict = null;
+
+        /**
+         * value list.
+         * @member {alc_dict.Ilist|null|undefined} list
+         * @memberof alc_dict.value
+         * @instance
+         */
+        value.prototype.list = null;
+
+        /**
+         * value str.
+         * @member {string} str
+         * @memberof alc_dict.value
+         * @instance
+         */
+        value.prototype.str = "";
+
+        /**
+         * value b.
+         * @member {boolean} b
+         * @memberof alc_dict.value
+         * @instance
+         */
+        value.prototype.b = false;
+
+        /**
+         * value i.
+         * @member {number} i
+         * @memberof alc_dict.value
+         * @instance
+         */
+        value.prototype.i = 0;
+
+        /**
+         * Creates a new value instance using the specified properties.
+         * @function create
+         * @memberof alc_dict.value
+         * @static
+         * @param {alc_dict.Ivalue=} [properties] Properties to set
+         * @returns {alc_dict.value} value instance
+         */
+        value.create = function create(properties) {
+            return new value(properties);
+        };
+
+        /**
+         * Encodes the specified value message. Does not implicitly {@link alc_dict.value.verify|verify} messages.
+         * @function encode
+         * @memberof alc_dict.value
+         * @static
+         * @param {alc_dict.Ivalue} message value message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        value.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.dict != null && message.hasOwnProperty("dict"))
+                $root.alc_dict.dict.encode(message.dict, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            if (message.list != null && message.hasOwnProperty("list"))
+                $root.alc_dict.list.encode(message.list, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            if (message.str != null && message.hasOwnProperty("str"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.str);
+            if (message.b != null && message.hasOwnProperty("b"))
+                writer.uint32(/* id 4, wireType 0 =*/32).bool(message.b);
+            if (message.i != null && message.hasOwnProperty("i"))
+                writer.uint32(/* id 5, wireType 0 =*/40).sint32(message.i);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified value message, length delimited. Does not implicitly {@link alc_dict.value.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof alc_dict.value
+         * @static
+         * @param {alc_dict.Ivalue} message value message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        value.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a value message from the specified reader or buffer.
+         * @function decode
+         * @memberof alc_dict.value
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {alc_dict.value} value
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        value.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.alc_dict.value();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.dict = $root.alc_dict.dict.decode(reader, reader.uint32());
+                    break;
+                case 2:
+                    message.list = $root.alc_dict.list.decode(reader, reader.uint32());
+                    break;
+                case 3:
+                    message.str = reader.string();
+                    break;
+                case 4:
+                    message.b = reader.bool();
+                    break;
+                case 5:
+                    message.i = reader.sint32();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a value message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof alc_dict.value
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {alc_dict.value} value
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        value.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a value message.
+         * @function verify
+         * @memberof alc_dict.value
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        value.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.dict != null && message.hasOwnProperty("dict")) {
+                var error = $root.alc_dict.dict.verify(message.dict);
+                if (error)
+                    return "dict." + error;
+            }
+            if (message.list != null && message.hasOwnProperty("list")) {
+                var error = $root.alc_dict.list.verify(message.list);
+                if (error)
+                    return "list." + error;
+            }
+            if (message.str != null && message.hasOwnProperty("str"))
+                if (!$util.isString(message.str))
+                    return "str: string expected";
+            if (message.b != null && message.hasOwnProperty("b"))
+                if (typeof message.b !== "boolean")
+                    return "b: boolean expected";
+            if (message.i != null && message.hasOwnProperty("i"))
+                if (!$util.isInteger(message.i))
+                    return "i: integer expected";
+            return null;
+        };
+
+        /**
+         * Creates a value message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof alc_dict.value
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {alc_dict.value} value
+         */
+        value.fromObject = function fromObject(object) {
+            if (object instanceof $root.alc_dict.value)
+                return object;
+            var message = new $root.alc_dict.value();
+            if (object.dict != null) {
+                if (typeof object.dict !== "object")
+                    throw TypeError(".alc_dict.value.dict: object expected");
+                message.dict = $root.alc_dict.dict.fromObject(object.dict);
+            }
+            if (object.list != null) {
+                if (typeof object.list !== "object")
+                    throw TypeError(".alc_dict.value.list: object expected");
+                message.list = $root.alc_dict.list.fromObject(object.list);
+            }
+            if (object.str != null)
+                message.str = String(object.str);
+            if (object.b != null)
+                message.b = Boolean(object.b);
+            if (object.i != null)
+                message.i = object.i | 0;
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a value message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof alc_dict.value
+         * @static
+         * @param {alc_dict.value} message value
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        value.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.dict = null;
+                object.list = null;
+                object.str = "";
+                object.b = false;
+                object.i = 0;
+            }
+            if (message.dict != null && message.hasOwnProperty("dict"))
+                object.dict = $root.alc_dict.dict.toObject(message.dict, options);
+            if (message.list != null && message.hasOwnProperty("list"))
+                object.list = $root.alc_dict.list.toObject(message.list, options);
+            if (message.str != null && message.hasOwnProperty("str"))
+                object.str = message.str;
+            if (message.b != null && message.hasOwnProperty("b"))
+                object.b = message.b;
+            if (message.i != null && message.hasOwnProperty("i"))
+                object.i = message.i;
+            return object;
+        };
+
+        /**
+         * Converts this value to JSON.
+         * @function toJSON
+         * @memberof alc_dict.value
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        value.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return value;
+    })();
+
+    alc_dict.list = (function() {
+
+        /**
+         * Properties of a list.
+         * @memberof alc_dict
+         * @interface Ilist
+         * @property {Array.<alc_dict.Ivalue>|null} [elem] list elem
+         */
+
+        /**
+         * Constructs a new list.
+         * @memberof alc_dict
+         * @classdesc Represents a list.
+         * @implements Ilist
+         * @constructor
+         * @param {alc_dict.Ilist=} [properties] Properties to set
+         */
+        function list(properties) {
+            this.elem = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * list elem.
+         * @member {Array.<alc_dict.Ivalue>} elem
+         * @memberof alc_dict.list
+         * @instance
+         */
+        list.prototype.elem = $util.emptyArray;
+
+        /**
+         * Creates a new list instance using the specified properties.
+         * @function create
+         * @memberof alc_dict.list
+         * @static
+         * @param {alc_dict.Ilist=} [properties] Properties to set
+         * @returns {alc_dict.list} list instance
+         */
+        list.create = function create(properties) {
+            return new list(properties);
+        };
+
+        /**
+         * Encodes the specified list message. Does not implicitly {@link alc_dict.list.verify|verify} messages.
+         * @function encode
+         * @memberof alc_dict.list
+         * @static
+         * @param {alc_dict.Ilist} message list message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        list.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.elem != null && message.elem.length)
+                for (var i = 0; i < message.elem.length; ++i)
+                    $root.alc_dict.value.encode(message.elem[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified list message, length delimited. Does not implicitly {@link alc_dict.list.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof alc_dict.list
+         * @static
+         * @param {alc_dict.Ilist} message list message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        list.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a list message from the specified reader or buffer.
+         * @function decode
+         * @memberof alc_dict.list
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {alc_dict.list} list
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        list.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.alc_dict.list();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    if (!(message.elem && message.elem.length))
+                        message.elem = [];
+                    message.elem.push($root.alc_dict.value.decode(reader, reader.uint32()));
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a list message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof alc_dict.list
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {alc_dict.list} list
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        list.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a list message.
+         * @function verify
+         * @memberof alc_dict.list
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        list.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.elem != null && message.hasOwnProperty("elem")) {
+                if (!Array.isArray(message.elem))
+                    return "elem: array expected";
+                for (var i = 0; i < message.elem.length; ++i) {
+                    var error = $root.alc_dict.value.verify(message.elem[i]);
+                    if (error)
+                        return "elem." + error;
+                }
+            }
+            return null;
+        };
+
+        /**
+         * Creates a list message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof alc_dict.list
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {alc_dict.list} list
+         */
+        list.fromObject = function fromObject(object) {
+            if (object instanceof $root.alc_dict.list)
+                return object;
+            var message = new $root.alc_dict.list();
+            if (object.elem) {
+                if (!Array.isArray(object.elem))
+                    throw TypeError(".alc_dict.list.elem: array expected");
+                message.elem = [];
+                for (var i = 0; i < object.elem.length; ++i) {
+                    if (typeof object.elem[i] !== "object")
+                        throw TypeError(".alc_dict.list.elem: object expected");
+                    message.elem[i] = $root.alc_dict.value.fromObject(object.elem[i]);
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a list message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof alc_dict.list
+         * @static
+         * @param {alc_dict.list} message list
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        list.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults)
+                object.elem = [];
+            if (message.elem && message.elem.length) {
+                object.elem = [];
+                for (var j = 0; j < message.elem.length; ++j)
+                    object.elem[j] = $root.alc_dict.value.toObject(message.elem[j], options);
+            }
+            return object;
+        };
+
+        /**
+         * Converts this list to JSON.
+         * @function toJSON
+         * @memberof alc_dict.list
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        list.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return list;
+    })();
+
+    return alc_dict;
+})();
+
+module.exports = $root;

--- a/proto/host_metadata.piqi.proto
+++ b/proto/host_metadata.piqi.proto
@@ -1,0 +1,11 @@
+package host_metadata;
+
+import "dict.piqi.proto";
+
+message metadata {
+    optional string host_uuid = 1;
+    required bytes data_checksum = 2;
+    optional uint64 timestamp = 3;
+    optional .alc_dict.dict data = 4;
+}
+

--- a/proto/host_metadata.piqi_pb.js
+++ b/proto/host_metadata.piqi_pb.js
@@ -1,0 +1,1235 @@
+/*eslint-disable block-scoped-var, id-length, no-control-regex, no-magic-numbers, no-prototype-builtins, no-redeclare, no-shadow, no-var, sort-vars*/
+"use strict";
+
+var $protobuf = require("protobufjs/minimal");
+
+// Common aliases
+var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
+
+// Exported root namespace
+var $root = $protobuf.roots["default"] || ($protobuf.roots["default"] = {});
+
+$root.host_metadata = (function() {
+
+    /**
+     * Namespace host_metadata.
+     * @exports host_metadata
+     * @namespace
+     */
+    var host_metadata = {};
+
+    host_metadata.metadata = (function() {
+
+        /**
+         * Properties of a metadata.
+         * @memberof host_metadata
+         * @interface Imetadata
+         * @property {string|null} [hostUuid] metadata hostUuid
+         * @property {Uint8Array} dataChecksum metadata dataChecksum
+         * @property {number|Long|null} [timestamp] metadata timestamp
+         * @property {alc_dict.Idict|null} [data] metadata data
+         */
+
+        /**
+         * Constructs a new metadata.
+         * @memberof host_metadata
+         * @classdesc Represents a metadata.
+         * @implements Imetadata
+         * @constructor
+         * @param {host_metadata.Imetadata=} [properties] Properties to set
+         */
+        function metadata(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * metadata hostUuid.
+         * @member {string} hostUuid
+         * @memberof host_metadata.metadata
+         * @instance
+         */
+        metadata.prototype.hostUuid = "";
+
+        /**
+         * metadata dataChecksum.
+         * @member {Uint8Array} dataChecksum
+         * @memberof host_metadata.metadata
+         * @instance
+         */
+        metadata.prototype.dataChecksum = $util.newBuffer([]);
+
+        /**
+         * metadata timestamp.
+         * @member {number|Long} timestamp
+         * @memberof host_metadata.metadata
+         * @instance
+         */
+        metadata.prototype.timestamp = $util.Long ? $util.Long.fromBits(0,0,true) : 0;
+
+        /**
+         * metadata data.
+         * @member {alc_dict.Idict|null|undefined} data
+         * @memberof host_metadata.metadata
+         * @instance
+         */
+        metadata.prototype.data = null;
+
+        /**
+         * Creates a new metadata instance using the specified properties.
+         * @function create
+         * @memberof host_metadata.metadata
+         * @static
+         * @param {host_metadata.Imetadata=} [properties] Properties to set
+         * @returns {host_metadata.metadata} metadata instance
+         */
+        metadata.create = function create(properties) {
+            return new metadata(properties);
+        };
+
+        /**
+         * Encodes the specified metadata message. Does not implicitly {@link host_metadata.metadata.verify|verify} messages.
+         * @function encode
+         * @memberof host_metadata.metadata
+         * @static
+         * @param {host_metadata.Imetadata} message metadata message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        metadata.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.hostUuid != null && message.hasOwnProperty("hostUuid"))
+                writer.uint32(/* id 1, wireType 2 =*/10).string(message.hostUuid);
+            writer.uint32(/* id 2, wireType 2 =*/18).bytes(message.dataChecksum);
+            if (message.timestamp != null && message.hasOwnProperty("timestamp"))
+                writer.uint32(/* id 3, wireType 0 =*/24).uint64(message.timestamp);
+            if (message.data != null && message.hasOwnProperty("data"))
+                $root.alc_dict.dict.encode(message.data, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified metadata message, length delimited. Does not implicitly {@link host_metadata.metadata.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof host_metadata.metadata
+         * @static
+         * @param {host_metadata.Imetadata} message metadata message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        metadata.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a metadata message from the specified reader or buffer.
+         * @function decode
+         * @memberof host_metadata.metadata
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {host_metadata.metadata} metadata
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        metadata.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.host_metadata.metadata();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.hostUuid = reader.string();
+                    break;
+                case 2:
+                    message.dataChecksum = reader.bytes();
+                    break;
+                case 3:
+                    message.timestamp = reader.uint64();
+                    break;
+                case 4:
+                    message.data = $root.alc_dict.dict.decode(reader, reader.uint32());
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            if (!message.hasOwnProperty("dataChecksum"))
+                throw $util.ProtocolError("missing required 'dataChecksum'", { instance: message });
+            return message;
+        };
+
+        /**
+         * Decodes a metadata message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof host_metadata.metadata
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {host_metadata.metadata} metadata
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        metadata.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a metadata message.
+         * @function verify
+         * @memberof host_metadata.metadata
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        metadata.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.hostUuid != null && message.hasOwnProperty("hostUuid"))
+                if (!$util.isString(message.hostUuid))
+                    return "hostUuid: string expected";
+            if (!(message.dataChecksum && typeof message.dataChecksum.length === "number" || $util.isString(message.dataChecksum)))
+                return "dataChecksum: buffer expected";
+            if (message.timestamp != null && message.hasOwnProperty("timestamp"))
+                if (!$util.isInteger(message.timestamp) && !(message.timestamp && $util.isInteger(message.timestamp.low) && $util.isInteger(message.timestamp.high)))
+                    return "timestamp: integer|Long expected";
+            if (message.data != null && message.hasOwnProperty("data")) {
+                var error = $root.alc_dict.dict.verify(message.data);
+                if (error)
+                    return "data." + error;
+            }
+            return null;
+        };
+
+        /**
+         * Creates a metadata message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof host_metadata.metadata
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {host_metadata.metadata} metadata
+         */
+        metadata.fromObject = function fromObject(object) {
+            if (object instanceof $root.host_metadata.metadata)
+                return object;
+            var message = new $root.host_metadata.metadata();
+            if (object.hostUuid != null)
+                message.hostUuid = String(object.hostUuid);
+            if (object.dataChecksum != null)
+                if (typeof object.dataChecksum === "string")
+                    $util.base64.decode(object.dataChecksum, message.dataChecksum = $util.newBuffer($util.base64.length(object.dataChecksum)), 0);
+                else if (object.dataChecksum.length)
+                    message.dataChecksum = object.dataChecksum;
+            if (object.timestamp != null)
+                if ($util.Long)
+                    (message.timestamp = $util.Long.fromValue(object.timestamp)).unsigned = true;
+                else if (typeof object.timestamp === "string")
+                    message.timestamp = parseInt(object.timestamp, 10);
+                else if (typeof object.timestamp === "number")
+                    message.timestamp = object.timestamp;
+                else if (typeof object.timestamp === "object")
+                    message.timestamp = new $util.LongBits(object.timestamp.low >>> 0, object.timestamp.high >>> 0).toNumber(true);
+            if (object.data != null) {
+                if (typeof object.data !== "object")
+                    throw TypeError(".host_metadata.metadata.data: object expected");
+                message.data = $root.alc_dict.dict.fromObject(object.data);
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a metadata message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof host_metadata.metadata
+         * @static
+         * @param {host_metadata.metadata} message metadata
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        metadata.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.hostUuid = "";
+                if (options.bytes === String)
+                    object.dataChecksum = "";
+                else {
+                    object.dataChecksum = [];
+                    if (options.bytes !== Array)
+                        object.dataChecksum = $util.newBuffer(object.dataChecksum);
+                }
+                if ($util.Long) {
+                    var long = new $util.Long(0, 0, true);
+                    object.timestamp = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                } else
+                    object.timestamp = options.longs === String ? "0" : 0;
+                object.data = null;
+            }
+            if (message.hostUuid != null && message.hasOwnProperty("hostUuid"))
+                object.hostUuid = message.hostUuid;
+            if (message.dataChecksum != null && message.hasOwnProperty("dataChecksum"))
+                object.dataChecksum = options.bytes === String ? $util.base64.encode(message.dataChecksum, 0, message.dataChecksum.length) : options.bytes === Array ? Array.prototype.slice.call(message.dataChecksum) : message.dataChecksum;
+            if (message.timestamp != null && message.hasOwnProperty("timestamp"))
+                if (typeof message.timestamp === "number")
+                    object.timestamp = options.longs === String ? String(message.timestamp) : message.timestamp;
+                else
+                    object.timestamp = options.longs === String ? $util.Long.prototype.toString.call(message.timestamp) : options.longs === Number ? new $util.LongBits(message.timestamp.low >>> 0, message.timestamp.high >>> 0).toNumber(true) : message.timestamp;
+            if (message.data != null && message.hasOwnProperty("data"))
+                object.data = $root.alc_dict.dict.toObject(message.data, options);
+            return object;
+        };
+
+        /**
+         * Converts this metadata to JSON.
+         * @function toJSON
+         * @memberof host_metadata.metadata
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        metadata.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return metadata;
+    })();
+
+    return host_metadata;
+})();
+
+$root.alc_dict = (function() {
+
+    /**
+     * Namespace alc_dict.
+     * @exports alc_dict
+     * @namespace
+     */
+    var alc_dict = {};
+
+    alc_dict.dict = (function() {
+
+        /**
+         * Properties of a dict.
+         * @memberof alc_dict
+         * @interface Idict
+         * @property {Array.<alc_dict.Ielem>|null} [elem] dict elem
+         */
+
+        /**
+         * Constructs a new dict.
+         * @memberof alc_dict
+         * @classdesc Represents a dict.
+         * @implements Idict
+         * @constructor
+         * @param {alc_dict.Idict=} [properties] Properties to set
+         */
+        function dict(properties) {
+            this.elem = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * dict elem.
+         * @member {Array.<alc_dict.Ielem>} elem
+         * @memberof alc_dict.dict
+         * @instance
+         */
+        dict.prototype.elem = $util.emptyArray;
+
+        /**
+         * Creates a new dict instance using the specified properties.
+         * @function create
+         * @memberof alc_dict.dict
+         * @static
+         * @param {alc_dict.Idict=} [properties] Properties to set
+         * @returns {alc_dict.dict} dict instance
+         */
+        dict.create = function create(properties) {
+            return new dict(properties);
+        };
+
+        /**
+         * Encodes the specified dict message. Does not implicitly {@link alc_dict.dict.verify|verify} messages.
+         * @function encode
+         * @memberof alc_dict.dict
+         * @static
+         * @param {alc_dict.Idict} message dict message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        dict.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.elem != null && message.elem.length)
+                for (var i = 0; i < message.elem.length; ++i)
+                    $root.alc_dict.elem.encode(message.elem[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified dict message, length delimited. Does not implicitly {@link alc_dict.dict.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof alc_dict.dict
+         * @static
+         * @param {alc_dict.Idict} message dict message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        dict.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a dict message from the specified reader or buffer.
+         * @function decode
+         * @memberof alc_dict.dict
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {alc_dict.dict} dict
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        dict.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.alc_dict.dict();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    if (!(message.elem && message.elem.length))
+                        message.elem = [];
+                    message.elem.push($root.alc_dict.elem.decode(reader, reader.uint32()));
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a dict message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof alc_dict.dict
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {alc_dict.dict} dict
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        dict.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a dict message.
+         * @function verify
+         * @memberof alc_dict.dict
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        dict.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.elem != null && message.hasOwnProperty("elem")) {
+                if (!Array.isArray(message.elem))
+                    return "elem: array expected";
+                for (var i = 0; i < message.elem.length; ++i) {
+                    var error = $root.alc_dict.elem.verify(message.elem[i]);
+                    if (error)
+                        return "elem." + error;
+                }
+            }
+            return null;
+        };
+
+        /**
+         * Creates a dict message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof alc_dict.dict
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {alc_dict.dict} dict
+         */
+        dict.fromObject = function fromObject(object) {
+            if (object instanceof $root.alc_dict.dict)
+                return object;
+            var message = new $root.alc_dict.dict();
+            if (object.elem) {
+                if (!Array.isArray(object.elem))
+                    throw TypeError(".alc_dict.dict.elem: array expected");
+                message.elem = [];
+                for (var i = 0; i < object.elem.length; ++i) {
+                    if (typeof object.elem[i] !== "object")
+                        throw TypeError(".alc_dict.dict.elem: object expected");
+                    message.elem[i] = $root.alc_dict.elem.fromObject(object.elem[i]);
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a dict message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof alc_dict.dict
+         * @static
+         * @param {alc_dict.dict} message dict
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        dict.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults)
+                object.elem = [];
+            if (message.elem && message.elem.length) {
+                object.elem = [];
+                for (var j = 0; j < message.elem.length; ++j)
+                    object.elem[j] = $root.alc_dict.elem.toObject(message.elem[j], options);
+            }
+            return object;
+        };
+
+        /**
+         * Converts this dict to JSON.
+         * @function toJSON
+         * @memberof alc_dict.dict
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        dict.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return dict;
+    })();
+
+    alc_dict.elem = (function() {
+
+        /**
+         * Properties of an elem.
+         * @memberof alc_dict
+         * @interface Ielem
+         * @property {string} key elem key
+         * @property {alc_dict.Ivalue|null} [value] elem value
+         */
+
+        /**
+         * Constructs a new elem.
+         * @memberof alc_dict
+         * @classdesc Represents an elem.
+         * @implements Ielem
+         * @constructor
+         * @param {alc_dict.Ielem=} [properties] Properties to set
+         */
+        function elem(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * elem key.
+         * @member {string} key
+         * @memberof alc_dict.elem
+         * @instance
+         */
+        elem.prototype.key = "";
+
+        /**
+         * elem value.
+         * @member {alc_dict.Ivalue|null|undefined} value
+         * @memberof alc_dict.elem
+         * @instance
+         */
+        elem.prototype.value = null;
+
+        /**
+         * Creates a new elem instance using the specified properties.
+         * @function create
+         * @memberof alc_dict.elem
+         * @static
+         * @param {alc_dict.Ielem=} [properties] Properties to set
+         * @returns {alc_dict.elem} elem instance
+         */
+        elem.create = function create(properties) {
+            return new elem(properties);
+        };
+
+        /**
+         * Encodes the specified elem message. Does not implicitly {@link alc_dict.elem.verify|verify} messages.
+         * @function encode
+         * @memberof alc_dict.elem
+         * @static
+         * @param {alc_dict.Ielem} message elem message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        elem.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            writer.uint32(/* id 1, wireType 2 =*/10).string(message.key);
+            if (message.value != null && message.hasOwnProperty("value"))
+                $root.alc_dict.value.encode(message.value, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified elem message, length delimited. Does not implicitly {@link alc_dict.elem.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof alc_dict.elem
+         * @static
+         * @param {alc_dict.Ielem} message elem message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        elem.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes an elem message from the specified reader or buffer.
+         * @function decode
+         * @memberof alc_dict.elem
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {alc_dict.elem} elem
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        elem.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.alc_dict.elem();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.key = reader.string();
+                    break;
+                case 2:
+                    message.value = $root.alc_dict.value.decode(reader, reader.uint32());
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            if (!message.hasOwnProperty("key"))
+                throw $util.ProtocolError("missing required 'key'", { instance: message });
+            return message;
+        };
+
+        /**
+         * Decodes an elem message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof alc_dict.elem
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {alc_dict.elem} elem
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        elem.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies an elem message.
+         * @function verify
+         * @memberof alc_dict.elem
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        elem.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (!$util.isString(message.key))
+                return "key: string expected";
+            if (message.value != null && message.hasOwnProperty("value")) {
+                var error = $root.alc_dict.value.verify(message.value);
+                if (error)
+                    return "value." + error;
+            }
+            return null;
+        };
+
+        /**
+         * Creates an elem message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof alc_dict.elem
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {alc_dict.elem} elem
+         */
+        elem.fromObject = function fromObject(object) {
+            if (object instanceof $root.alc_dict.elem)
+                return object;
+            var message = new $root.alc_dict.elem();
+            if (object.key != null)
+                message.key = String(object.key);
+            if (object.value != null) {
+                if (typeof object.value !== "object")
+                    throw TypeError(".alc_dict.elem.value: object expected");
+                message.value = $root.alc_dict.value.fromObject(object.value);
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from an elem message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof alc_dict.elem
+         * @static
+         * @param {alc_dict.elem} message elem
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        elem.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.key = "";
+                object.value = null;
+            }
+            if (message.key != null && message.hasOwnProperty("key"))
+                object.key = message.key;
+            if (message.value != null && message.hasOwnProperty("value"))
+                object.value = $root.alc_dict.value.toObject(message.value, options);
+            return object;
+        };
+
+        /**
+         * Converts this elem to JSON.
+         * @function toJSON
+         * @memberof alc_dict.elem
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        elem.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return elem;
+    })();
+
+    alc_dict.value = (function() {
+
+        /**
+         * Properties of a value.
+         * @memberof alc_dict
+         * @interface Ivalue
+         * @property {alc_dict.Idict|null} [dict] value dict
+         * @property {alc_dict.Ilist|null} [list] value list
+         * @property {string|null} [str] value str
+         * @property {boolean|null} [b] value b
+         * @property {number|null} [i] value i
+         */
+
+        /**
+         * Constructs a new value.
+         * @memberof alc_dict
+         * @classdesc Represents a value.
+         * @implements Ivalue
+         * @constructor
+         * @param {alc_dict.Ivalue=} [properties] Properties to set
+         */
+        function value(properties) {
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * value dict.
+         * @member {alc_dict.Idict|null|undefined} dict
+         * @memberof alc_dict.value
+         * @instance
+         */
+        value.prototype.dict = null;
+
+        /**
+         * value list.
+         * @member {alc_dict.Ilist|null|undefined} list
+         * @memberof alc_dict.value
+         * @instance
+         */
+        value.prototype.list = null;
+
+        /**
+         * value str.
+         * @member {string} str
+         * @memberof alc_dict.value
+         * @instance
+         */
+        value.prototype.str = "";
+
+        /**
+         * value b.
+         * @member {boolean} b
+         * @memberof alc_dict.value
+         * @instance
+         */
+        value.prototype.b = false;
+
+        /**
+         * value i.
+         * @member {number} i
+         * @memberof alc_dict.value
+         * @instance
+         */
+        value.prototype.i = 0;
+
+        /**
+         * Creates a new value instance using the specified properties.
+         * @function create
+         * @memberof alc_dict.value
+         * @static
+         * @param {alc_dict.Ivalue=} [properties] Properties to set
+         * @returns {alc_dict.value} value instance
+         */
+        value.create = function create(properties) {
+            return new value(properties);
+        };
+
+        /**
+         * Encodes the specified value message. Does not implicitly {@link alc_dict.value.verify|verify} messages.
+         * @function encode
+         * @memberof alc_dict.value
+         * @static
+         * @param {alc_dict.Ivalue} message value message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        value.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.dict != null && message.hasOwnProperty("dict"))
+                $root.alc_dict.dict.encode(message.dict, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            if (message.list != null && message.hasOwnProperty("list"))
+                $root.alc_dict.list.encode(message.list, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+            if (message.str != null && message.hasOwnProperty("str"))
+                writer.uint32(/* id 3, wireType 2 =*/26).string(message.str);
+            if (message.b != null && message.hasOwnProperty("b"))
+                writer.uint32(/* id 4, wireType 0 =*/32).bool(message.b);
+            if (message.i != null && message.hasOwnProperty("i"))
+                writer.uint32(/* id 5, wireType 0 =*/40).sint32(message.i);
+            return writer;
+        };
+
+        /**
+         * Encodes the specified value message, length delimited. Does not implicitly {@link alc_dict.value.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof alc_dict.value
+         * @static
+         * @param {alc_dict.Ivalue} message value message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        value.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a value message from the specified reader or buffer.
+         * @function decode
+         * @memberof alc_dict.value
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {alc_dict.value} value
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        value.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.alc_dict.value();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    message.dict = $root.alc_dict.dict.decode(reader, reader.uint32());
+                    break;
+                case 2:
+                    message.list = $root.alc_dict.list.decode(reader, reader.uint32());
+                    break;
+                case 3:
+                    message.str = reader.string();
+                    break;
+                case 4:
+                    message.b = reader.bool();
+                    break;
+                case 5:
+                    message.i = reader.sint32();
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a value message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof alc_dict.value
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {alc_dict.value} value
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        value.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a value message.
+         * @function verify
+         * @memberof alc_dict.value
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        value.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.dict != null && message.hasOwnProperty("dict")) {
+                var error = $root.alc_dict.dict.verify(message.dict);
+                if (error)
+                    return "dict." + error;
+            }
+            if (message.list != null && message.hasOwnProperty("list")) {
+                var error = $root.alc_dict.list.verify(message.list);
+                if (error)
+                    return "list." + error;
+            }
+            if (message.str != null && message.hasOwnProperty("str"))
+                if (!$util.isString(message.str))
+                    return "str: string expected";
+            if (message.b != null && message.hasOwnProperty("b"))
+                if (typeof message.b !== "boolean")
+                    return "b: boolean expected";
+            if (message.i != null && message.hasOwnProperty("i"))
+                if (!$util.isInteger(message.i))
+                    return "i: integer expected";
+            return null;
+        };
+
+        /**
+         * Creates a value message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof alc_dict.value
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {alc_dict.value} value
+         */
+        value.fromObject = function fromObject(object) {
+            if (object instanceof $root.alc_dict.value)
+                return object;
+            var message = new $root.alc_dict.value();
+            if (object.dict != null) {
+                if (typeof object.dict !== "object")
+                    throw TypeError(".alc_dict.value.dict: object expected");
+                message.dict = $root.alc_dict.dict.fromObject(object.dict);
+            }
+            if (object.list != null) {
+                if (typeof object.list !== "object")
+                    throw TypeError(".alc_dict.value.list: object expected");
+                message.list = $root.alc_dict.list.fromObject(object.list);
+            }
+            if (object.str != null)
+                message.str = String(object.str);
+            if (object.b != null)
+                message.b = Boolean(object.b);
+            if (object.i != null)
+                message.i = object.i | 0;
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a value message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof alc_dict.value
+         * @static
+         * @param {alc_dict.value} message value
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        value.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.defaults) {
+                object.dict = null;
+                object.list = null;
+                object.str = "";
+                object.b = false;
+                object.i = 0;
+            }
+            if (message.dict != null && message.hasOwnProperty("dict"))
+                object.dict = $root.alc_dict.dict.toObject(message.dict, options);
+            if (message.list != null && message.hasOwnProperty("list"))
+                object.list = $root.alc_dict.list.toObject(message.list, options);
+            if (message.str != null && message.hasOwnProperty("str"))
+                object.str = message.str;
+            if (message.b != null && message.hasOwnProperty("b"))
+                object.b = message.b;
+            if (message.i != null && message.hasOwnProperty("i"))
+                object.i = message.i;
+            return object;
+        };
+
+        /**
+         * Converts this value to JSON.
+         * @function toJSON
+         * @memberof alc_dict.value
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        value.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return value;
+    })();
+
+    alc_dict.list = (function() {
+
+        /**
+         * Properties of a list.
+         * @memberof alc_dict
+         * @interface Ilist
+         * @property {Array.<alc_dict.Ivalue>|null} [elem] list elem
+         */
+
+        /**
+         * Constructs a new list.
+         * @memberof alc_dict
+         * @classdesc Represents a list.
+         * @implements Ilist
+         * @constructor
+         * @param {alc_dict.Ilist=} [properties] Properties to set
+         */
+        function list(properties) {
+            this.elem = [];
+            if (properties)
+                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                    if (properties[keys[i]] != null)
+                        this[keys[i]] = properties[keys[i]];
+        }
+
+        /**
+         * list elem.
+         * @member {Array.<alc_dict.Ivalue>} elem
+         * @memberof alc_dict.list
+         * @instance
+         */
+        list.prototype.elem = $util.emptyArray;
+
+        /**
+         * Creates a new list instance using the specified properties.
+         * @function create
+         * @memberof alc_dict.list
+         * @static
+         * @param {alc_dict.Ilist=} [properties] Properties to set
+         * @returns {alc_dict.list} list instance
+         */
+        list.create = function create(properties) {
+            return new list(properties);
+        };
+
+        /**
+         * Encodes the specified list message. Does not implicitly {@link alc_dict.list.verify|verify} messages.
+         * @function encode
+         * @memberof alc_dict.list
+         * @static
+         * @param {alc_dict.Ilist} message list message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        list.encode = function encode(message, writer) {
+            if (!writer)
+                writer = $Writer.create();
+            if (message.elem != null && message.elem.length)
+                for (var i = 0; i < message.elem.length; ++i)
+                    $root.alc_dict.value.encode(message.elem[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+            return writer;
+        };
+
+        /**
+         * Encodes the specified list message, length delimited. Does not implicitly {@link alc_dict.list.verify|verify} messages.
+         * @function encodeDelimited
+         * @memberof alc_dict.list
+         * @static
+         * @param {alc_dict.Ilist} message list message or plain object to encode
+         * @param {$protobuf.Writer} [writer] Writer to encode to
+         * @returns {$protobuf.Writer} Writer
+         */
+        list.encodeDelimited = function encodeDelimited(message, writer) {
+            return this.encode(message, writer).ldelim();
+        };
+
+        /**
+         * Decodes a list message from the specified reader or buffer.
+         * @function decode
+         * @memberof alc_dict.list
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @param {number} [length] Message length if known beforehand
+         * @returns {alc_dict.list} list
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        list.decode = function decode(reader, length) {
+            if (!(reader instanceof $Reader))
+                reader = $Reader.create(reader);
+            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.alc_dict.list();
+            while (reader.pos < end) {
+                var tag = reader.uint32();
+                switch (tag >>> 3) {
+                case 1:
+                    if (!(message.elem && message.elem.length))
+                        message.elem = [];
+                    message.elem.push($root.alc_dict.value.decode(reader, reader.uint32()));
+                    break;
+                default:
+                    reader.skipType(tag & 7);
+                    break;
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Decodes a list message from the specified reader or buffer, length delimited.
+         * @function decodeDelimited
+         * @memberof alc_dict.list
+         * @static
+         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+         * @returns {alc_dict.list} list
+         * @throws {Error} If the payload is not a reader or valid buffer
+         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+         */
+        list.decodeDelimited = function decodeDelimited(reader) {
+            if (!(reader instanceof $Reader))
+                reader = new $Reader(reader);
+            return this.decode(reader, reader.uint32());
+        };
+
+        /**
+         * Verifies a list message.
+         * @function verify
+         * @memberof alc_dict.list
+         * @static
+         * @param {Object.<string,*>} message Plain object to verify
+         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+         */
+        list.verify = function verify(message) {
+            if (typeof message !== "object" || message === null)
+                return "object expected";
+            if (message.elem != null && message.hasOwnProperty("elem")) {
+                if (!Array.isArray(message.elem))
+                    return "elem: array expected";
+                for (var i = 0; i < message.elem.length; ++i) {
+                    var error = $root.alc_dict.value.verify(message.elem[i]);
+                    if (error)
+                        return "elem." + error;
+                }
+            }
+            return null;
+        };
+
+        /**
+         * Creates a list message from a plain object. Also converts values to their respective internal types.
+         * @function fromObject
+         * @memberof alc_dict.list
+         * @static
+         * @param {Object.<string,*>} object Plain object
+         * @returns {alc_dict.list} list
+         */
+        list.fromObject = function fromObject(object) {
+            if (object instanceof $root.alc_dict.list)
+                return object;
+            var message = new $root.alc_dict.list();
+            if (object.elem) {
+                if (!Array.isArray(object.elem))
+                    throw TypeError(".alc_dict.list.elem: array expected");
+                message.elem = [];
+                for (var i = 0; i < object.elem.length; ++i) {
+                    if (typeof object.elem[i] !== "object")
+                        throw TypeError(".alc_dict.list.elem: object expected");
+                    message.elem[i] = $root.alc_dict.value.fromObject(object.elem[i]);
+                }
+            }
+            return message;
+        };
+
+        /**
+         * Creates a plain object from a list message. Also converts values to other types if specified.
+         * @function toObject
+         * @memberof alc_dict.list
+         * @static
+         * @param {alc_dict.list} message list
+         * @param {$protobuf.IConversionOptions} [options] Conversion options
+         * @returns {Object.<string,*>} Plain object
+         */
+        list.toObject = function toObject(message, options) {
+            if (!options)
+                options = {};
+            var object = {};
+            if (options.arrays || options.defaults)
+                object.elem = [];
+            if (message.elem && message.elem.length) {
+                object.elem = [];
+                for (var j = 0; j < message.elem.length; ++j)
+                    object.elem[j] = $root.alc_dict.value.toObject(message.elem[j], options);
+            }
+            return object;
+        };
+
+        /**
+         * Converts this list to JSON.
+         * @function toJSON
+         * @memberof alc_dict.list
+         * @instance
+         * @returns {Object.<string,*>} JSON object
+         */
+        list.prototype.toJSON = function toJSON() {
+            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+        };
+
+        return list;
+    })();
+
+    return alc_dict;
+})();
+
+module.exports = $root;

--- a/test/aimsc_test.js
+++ b/test/aimsc_test.js
@@ -1,13 +1,21 @@
+/* -----------------------------------------------------------------------------
+ * @copyright (C) 2018, Alert Logic, Inc
+ * @doc
+ *
+ * AIMs client tests
+ *
+ * @end
+ * -----------------------------------------------------------------------------
+ */
+
 const fs = require('fs');
 const assert = require('assert');
-const rewire = require('rewire');
 const sinon = require('sinon');
 const tk = require('timekeeper');
 const AimsC = require('../al_servicec').AimsC;
 const AzcollectC = require('../al_servicec').AzcollectC;
 const m_alMock = require('./al_mock');
 const debug = require('debug') ('azcollectc_test');
-var servicecRewire = rewire('../al_servicec');
 var m_servicec = require('../al_servicec');
 var RestServiceClient = require('../al_util').RestServiceClient;
 
@@ -49,6 +57,8 @@ describe('Unit Tests', function() {
 
         after(function() {
             clean_file_cache(m_alMock.CACHE_FILENAME);
+            fakeRest.restore();
+            tk.reset();
         });
 
         it('authenticate with cold cache', function(done) {

--- a/test/al_log_test.js
+++ b/test/al_log_test.js
@@ -1,0 +1,169 @@
+/* -----------------------------------------------------------------------------
+ * @copyright (C) 2018, Alert Logic, Inc
+ * @doc
+ *
+ * Tests for log data processing.
+ *
+ * @end
+ * -----------------------------------------------------------------------------
+ */
+
+const assert = require('assert');
+const sinon = require('sinon');
+const alLog = require('../al_log');
+const m_alMock = require('./al_mock');
+const m_alService = require('../al_servicec');
+const m_alUtil = require('../al_util');
+
+
+describe('Unit Tests', function() {
+    describe('Build log payload', function() {
+        var clock;
+        
+        before(function(){
+            clock = sinon.useFakeTimers();
+        });
+        after(function() {
+            clock.restore();
+        });
+
+        it('Sunny case ', function(done) {
+            var hostTypeElem = {
+                key: 'host_type',
+                value: {str: 'azure_fun'}
+            };
+            var localHostnameElem = {
+                key: 'local_hostname',
+                value: {str: 'somename'}
+            };
+            var hml = [localHostnameElem, hostTypeElem];
+            var msgs = [
+                'message1',
+                'message2'
+            ];
+            
+            var parseFun = function(m) {
+                var messagePayload = {
+                  messageTs: 1542138053,
+                  priority: 11,
+                  progName: 'o365webhook',
+                  pid: undefined,
+                  message: m,
+                  messageType: 'json/azure.o365',
+                  messageTypeId: 'AzureActiveDirectory',
+                  messageTsUs: undefined
+                };
+                
+                return messagePayload;
+            };
+            var expectedPayload = 'eJzjamHi4izOLy1KTtXNTBGK5mLPyC8uATFFdm6e97ZBfLqW665Nbkkbdic+E771WoJByYJLhosvJz85MScepDQvMTdViEuKozg/NxXE5pLg4gSJx5dUFqQKcUtxJlaVFqXGp5XmSfkIHtV4Hc0ABLLcQEKJO9/YzLQ8NSkjPz/biCM3tbg4MT3V0Io/qzg/Tx+sTQ+kwknEEcR2TC7JLEt1ySxKTS7JL6okzjQjIk0DAFuCVYc=';
+            alLog.buildPayload('host-id', 'source-id', hml, msgs, parseFun, function(err, payload){
+                assert.equal(expectedPayload, new Buffer(payload).toString('base64'));
+                return done();
+            });
+        });
+
+        it('Too many messages ', function(done) {
+            var hostTypeElem = {
+                key: 'host_type',
+                value: {str: 'azure_fun'}
+            };
+            var localHostnameElem = {
+                key: 'local_hostname',
+                value: {str: 'somename'}
+            };
+            var hml = [localHostnameElem, hostTypeElem];
+            var msgs = [];
+            for (let i=0; i<70000; i++){
+                msgs.push('very-long-message' + Math.random());
+            }
+            
+            var parseFun = function(m) {
+                var messagePayload = {
+                  messageTs: 1542138053,
+                  priority: 11,
+                  progName: 'o365webhook',
+                  pid: undefined,
+                  message: m,
+                  messageType: 'json/azure.o365',
+                  messageTypeId: 'AzureActiveDirectory',
+                  messageTsUs: undefined
+                };
+                // Let's make a message bigger
+                messagePayload.message = JSON.stringify(messagePayload);
+                return messagePayload;
+            };
+            var expectedPayload = '';
+            alLog.buildPayload('host-id', 'source-id', hml, msgs, parseFun, function(err, payload){
+                sinon.match(err, 'Maximum payload size exceeded');
+                return done();
+            });
+        });
+
+        it('Wrong hostmeta build error ', function(done) {
+            var hostTypeElem = {
+                value: {str: 'azure_fun'}
+            };
+            var localHostnameElem = {
+                key: 'local_hostname',
+                value: {str: 'somename'}
+            };
+            var hml = [localHostnameElem, hostTypeElem];
+            var msgs = [
+                'message1',
+                'message2'
+            ];
+            
+            var parseFun = function(m) {
+                var messagePayload = {
+                  messageTs: 1542138053,
+                  priority: 11,
+                  progName: 'o365webhook',
+                  pid: undefined,
+                  message: m,
+                  messageType: 'json/azure.o365',
+                  messageTypeId: 'AzureActiveDirectory',
+                  messageTsUs: undefined
+                };
+                
+                return messagePayload;
+            };
+            alLog.buildPayload('host-id', 'source-id', hml, msgs, parseFun, function(err, payload){
+                assert.equal(err, 'elem.key: string expected');
+                return done();
+            });
+        });
+
+        it('Wrong pasred message build error ', function(done) {
+            var localHostnameElem = {
+                key: 'local_hostname',
+                value: {str: 'somename'}
+            };
+            var hml = [localHostnameElem];
+            var msgs = [
+                'message1',
+                'message2'
+            ];
+            
+            var parseFun = function(m) {
+                var messagePayload = {
+                  //messageTs: 1542138053,
+                  priority: 11,
+                  progName: 'o365webhook',
+                  pid: undefined,
+                  message: m,
+                  messageType: 'json/azure.o365',
+                  messageTypeId: 'AzureActiveDirectory',
+                  messageTsUs: undefined
+                };
+                
+                return messagePayload;
+            };
+            alLog.buildPayload('host-id', 'source-id', hml, msgs, parseFun, function(err, payload){
+                assert.equal(err, 'messageTs: integer|Long expected');
+                return done();
+            });
+        });
+
+    });
+});

--- a/test/al_mock.js
+++ b/test/al_mock.js
@@ -1,3 +1,12 @@
+/* -----------------------------------------------------------------------------
+ * @copyright (C) 2018, Alert Logic, Inc
+ * @doc
+ *
+ * Predefined constants for the tests.
+ *
+ * @end
+ * -----------------------------------------------------------------------------
+ */
 const zlib = require('zlib');
 
 const AIMS_CREDS = {
@@ -56,6 +65,55 @@ const AZCOLLECT_CHECKIN_QUERY_COMPRESSED = {
     body : COMPRESSED_CHECKIN_BODY
 };
 
+const AIMS_RESPONSE_200 = {
+        'authentication': {
+            'user': {
+              'id': '9166F39C-7EE9-44C2-9975-7229E4A220F4',
+              'account_id': '134274125',
+              'name': 'user-name',
+              'email': 'username@gmail.com',
+              'active': true,
+              'locked': false,
+              'version': 2,
+              'linked_users': [
+                {
+                  'user_id': 2100000140,
+                  'location': 'defender-us-ashburn'
+                }
+              ],
+              'created': {
+                'at': 1504004320,
+                'by': 'B860236A-000F-4608-BCDD-5878BF815A9B'
+              },
+              'modified': {
+                'at': 1504004321,
+                'by': 'B860236A-000F-4608-BCDD-5878BF815A9B'
+              }
+            },
+            'account': {
+              'id': '134274125',
+              'name': 'RCS-LM-Test',
+              'active': true,
+              'version': 6,
+              'accessible_locations': [
+                'defender-us-ashburn',
+                'insight-us-virginia'
+              ],
+              'default_location': 'defender-us-ashburn',
+              'created': {
+                'at': 1502279387,
+                'by': '702DDB3B-BEE0-4565-93D6-D525034C9DFD'
+              },
+              'modified': {
+                'at': 1505926844,
+                'by': 'CBE203A9-168D-4E8D-8B73-5E20F38B47A1'
+              }
+            },
+            'token': 'some-token',
+            'token_expiration': 1542318145
+          }
+        };
+
 function gen_auth_response() {
     return {
         authentication : {
@@ -80,6 +138,8 @@ module.exports = {
     CHECKIN : CHECKIN,
     AZCOLLECT_CHECKIN_QUERY : AZCOLLECT_CHECKIN_QUERY,
     AZCOLLECT_CHECKIN_QUERY_COMPRESSED : AZCOLLECT_CHECKIN_QUERY_COMPRESSED,
+    AIMS_RESPONSE_200: AIMS_RESPONSE_200,
 
     gen_auth_response : gen_auth_response
 };
+

--- a/test/al_util_test.js
+++ b/test/al_util_test.js
@@ -1,5 +1,15 @@
+/* -----------------------------------------------------------------------------
+ * @copyright (C) 2018, Alert Logic, Inc
+ * @doc
+ *
+ * Mainly tests for REST service client
+ *
+ * @end
+ * -----------------------------------------------------------------------------
+ */
+
+const fs = require('fs');
 const assert = require('assert');
-const rewire = require('rewire');
 const sinon = require('sinon');
 const nock = require('nock');
 const rp = require('request-promise-native');
@@ -7,7 +17,6 @@ const req = require('request');
 const RestServiceClient = require('../al_util').RestServiceClient;
 const m_alMock = require('./al_mock');
 const debug = require('debug') ('azcollectc_test');
-var servicecRewire = rewire('../al_servicec');
 var m_servicec = require('../al_servicec');
 
 const TEST_PATH = '/some/path';
@@ -20,6 +29,19 @@ const TEST_BODY = {
 describe('Unit Tests', function() {
 
     describe('RestServiceClient', function() {
+        beforeEach(function(done) {
+            if (!nock.isActive()) {
+                nock.activate();
+            }
+            done();
+        });
+        afterEach(function(done) {
+            nock.cleanAll();
+            fs.unlink(m_alMock.CACHE_FILENAME, function(err){
+                done();
+            });
+        });
+        
         it('test request', function(done) {
             var restC = new RestServiceClient(m_alMock.AL_API);
             var restMock = nock('https://' + m_alMock.AL_API, {
@@ -32,7 +54,7 @@ describe('Unit Tests', function() {
                 })
                 .post(TEST_PATH, TEST_BODY)
                 .times(1)
-                .reply(204);
+                .reply(204, m_alMock.AIMS_RESPONSE_200);
             restC.request('POST', TEST_PATH, {
                 headers : {'some_header' : 'some_value'},
                 body : TEST_BODY
@@ -55,7 +77,7 @@ describe('Unit Tests', function() {
                 })
                 .post(TEST_PATH, TEST_BODY)
                 .times(1)
-                .reply(204);
+                .reply(204, m_alMock.AIMS_RESPONSE_200);
             restC.post(TEST_PATH, {
                 headers : {'some_header' : 'some_value'},
                 body : TEST_BODY
@@ -77,7 +99,7 @@ describe('Unit Tests', function() {
                 })
                 .get(TEST_PATH)
                 .times(1)
-                .reply(204);
+                .reply(204, m_alMock.AIMS_RESPONSE_200);
             restC.get(TEST_PATH, {
                 headers : {'some_header' : 'some_value'}
             })
@@ -98,7 +120,7 @@ describe('Unit Tests', function() {
                 })
                 .delete(TEST_PATH)
                 .times(1)
-                .reply(204);
+                .reply(204, m_alMock.AIMS_RESPONSE_200);
             restC.deleteRequest(TEST_PATH, {
                 headers : {'some_header' : 'some_value'}
             })

--- a/test/alservicec_test.js
+++ b/test/alservicec_test.js
@@ -1,12 +1,21 @@
+/* -----------------------------------------------------------------------------
+ * @copyright (C) 2018, Alert Logic, Inc
+ * @doc
+ *
+ * Tests for base Alert Logic service client
+ *
+ * @end
+ * -----------------------------------------------------------------------------
+ */
+
+const fs = require('fs');
 const assert = require('assert');
-const rewire = require('rewire');
 const sinon = require('sinon');
 const AimsC = require('../al_servicec').AimsC;
 const AzcollectC = require('../al_servicec').AzcollectC;
 const AlServiceC = require('../al_servicec').AlServiceC;
 const m_alMock = require('./al_mock');
 const debug = require('debug') ('azcollectc_test');
-var servicecRewire = rewire('../al_servicec');
 var m_servicec = require('../al_servicec');
 var RestServiceClient = require('../al_util').RestServiceClient;
 
@@ -18,7 +27,8 @@ describe('Unit Tests', function() {
         var fakeRequest;
 
         beforeEach(function() {
-            fakeAims = sinon.stub(RestServiceClient.prototype, 'post').callsFake(
+            fakeAims = sinon.stub(RestServiceClient.prototype, 'post');
+            fakeAims.callsFake(
                 function fakeFn(path, options) {
                     if (path == '/aims/v1/authenticate' &&
                         options.auth.user == m_alMock.AIMS_AUTH.auth.user &&
@@ -42,11 +52,13 @@ describe('Unit Tests', function() {
             );
         });
 
-        afterEach(function() {
+        afterEach(function(done) {
             fakeRequest.restore();
             fakeAims.restore();
+            fs.unlink(m_alMock.CACHE_FILENAME, function(err){
+                done();
+            });
         });
-
 
         it('check request is called with correct headers', function(done) {
             var aimsC = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);

--- a/test/azcollectc_test.js
+++ b/test/azcollectc_test.js
@@ -1,12 +1,20 @@
+/* -----------------------------------------------------------------------------
+ * @copyright (C) 2018, Alert Logic, Inc
+ * @doc
+ *
+ * Tests for Alert Logic Azcollect service client
+ *
+ * @end
+ * -----------------------------------------------------------------------------
+ */
 
+const fs = require('fs');
 const assert = require('assert');
-const rewire = require('rewire');
 const sinon = require('sinon');
 const AimsC = require('../al_servicec').AimsC;
 const AzcollectC = require('../al_servicec').AzcollectC;
 const m_alMock = require('./al_mock');
 const debug = require('debug') ('azcollectc_test');
-var servicecRewire = rewire('../al_servicec');
 var m_servicec = require('../al_servicec');
 var RestServiceClient = require('../al_util').RestServiceClient;
 
@@ -40,12 +48,15 @@ describe('Unit Tests', function() {
                 });
         });
         
-        afterEach(function() {
+        afterEach(function(done) {
             fakePost.restore();
             fakeDel.restore();
             fakeAuth.restore();
+            fs.unlink(m_alMock.CACHE_FILENAME, function(err){
+                done();
+            });
         });
-
+        
         it('register no data type', function(done) {
             var aimsc = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
             var azc = new AzcollectC(m_alMock.INGEST_ENDPOINT, aimsc, 'cwe');

--- a/test/endpointsc_test.js
+++ b/test/endpointsc_test.js
@@ -1,12 +1,20 @@
+/* -----------------------------------------------------------------------------
+ * @copyright (C) 2018, Alert Logic, Inc
+ * @doc
+ *
+ * Tests for Alert Logic Endpoints service client
+ *
+ * @end
+ * -----------------------------------------------------------------------------
+ */
+const fs = require('fs');
 const assert = require('assert');
-const rewire = require('rewire');
 const sinon = require('sinon');
 const AimsC = require('../al_servicec').AimsC;
 const AzcollectC = require('../al_servicec').AzcollectC;
 const EndpointsC = require('../al_servicec').EndpointsC;
 const m_alMock = require('./al_mock');
 const debug = require('debug') ('azcollectc_test');
-var servicecRewire = rewire('../al_servicec');
 var m_servicec = require('../al_servicec');
 var RestServiceClient = require('../al_util').RestServiceClient;
 
@@ -32,11 +40,14 @@ describe('Unit Tests', function() {
             });
         });
 
-        afterEach(function() {
+        afterEach(function(done) {
             fakeGet.restore();
             fakeAuth.restore();
+            fs.unlink(m_alMock.CACHE_FILENAME, function(err){
+                done();
+            });
         });
-
+        
         it('getEndpoint', function(done) {
             var aimsc = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
             var endpointsC = new EndpointsC(m_alMock.AL_API, aimsc, 'cwe');

--- a/test/ingestc_test.js
+++ b/test/ingestc_test.js
@@ -1,12 +1,19 @@
-
+/* -----------------------------------------------------------------------------
+ * @copyright (C) 2018, Alert Logic, Inc
+ * @doc
+ *
+ * Tests for Alert Logic Ingest service client
+ *
+ * @end
+ * -----------------------------------------------------------------------------
+ */
+const fs = require('fs');
 const assert = require('assert');
-const rewire = require('rewire');
 const sinon = require('sinon');
 const AimsC = require('../al_servicec').AimsC;
 const IngestC = require('../al_servicec').IngestC;
 const m_alMock = require('./al_mock');
 const debug = require('debug') ('ingestc_test');
-var servicecRewire = rewire('../al_servicec');
 var m_servicec = require('../al_servicec');
 
 describe('Unit Tests', function() {
@@ -23,9 +30,12 @@ describe('Unit Tests', function() {
                     });
             });
         });
-        afterEach(function() {
+        afterEach(function(done) {
             fakePost.restore();
             fakeAuth.restore();
+            fs.unlink(m_alMock.CACHE_FILENAME, function(err){
+                done();
+            });
         });
 
         it('Verify secmsgs body', function(done) {

--- a/test/request_retry_test.js
+++ b/test/request_retry_test.js
@@ -1,0 +1,187 @@
+/* -----------------------------------------------------------------------------
+ * @copyright (C) 2018, Alert Logic, Inc
+ * @doc
+ *
+ * Tests for request retry
+ *
+ * @end
+ * -----------------------------------------------------------------------------
+ */
+
+const fs = require('fs');
+const assert = require('assert');
+const nock = require('nock');
+const m_alMock = require('./al_mock');
+const alLog = require('../al_log');
+const m_alService = require('../al_servicec');
+
+describe('HTTP request retry tests', function() {
+    beforeEach(function(done) {
+        if (!nock.isActive()) {
+            nock.activate();
+        }
+        done();
+    });
+    afterEach(function(done) {
+        nock.cleanAll();
+        fs.unlink(m_alMock.CACHE_FILENAME, function(err){
+            done();
+        });
+    });
+
+    it('No retries on success', function(done) {
+        
+        var aimsMock = nock('https://' + m_alMock.AL_API)
+            .post('/aims/v1/authenticate')
+            .reply(200, m_alMock.AIMS_RESPONSE_200)
+            .post('/aims/v1/authenticate')
+            .reply(401, {statusCode: 401});
+        var retryOptions = {
+            minTimeout: 2000,
+            retries: 5,
+            maxTimeout: 30000
+        };
+        
+        var aimsc = new m_alService.AimsC(
+                m_alMock.AL_API, m_alMock.AIMS_CREDS, '/tmp', retryOptions);
+        aimsc.authenticate()
+            .then(resp => {
+                assert.equal(resp.authentication.user.name, 'user-name');
+                return done();
+            });
+    });
+    
+    it('No retries on success with default retry config', function(done) {
+        var aimsMock = nock('https://' + m_alMock.AL_API)
+            .post('/aims/v1/authenticate')
+            .reply(200, m_alMock.AIMS_RESPONSE_200)
+            .post('/aims/v1/authenticate')
+            .reply(401, {statusCode: 401});
+        var aimsc = new m_alService.AimsC(
+                m_alMock.AL_API, m_alMock.AIMS_CREDS, '/tmp');
+        aimsc.authenticate()
+            .then(resp => {
+                assert.equal(resp.authentication.user.name, 'user-name');
+                return done();
+            });
+    });
+    
+    it('Retry 500 with default retry config', function(done) {
+        this.timeout(4000);
+        var aimsMock = nock('https://' + m_alMock.AL_API)
+            .post('/aims/v1/authenticate')
+            .reply(500, {statusCode: 500})
+            .post('/aims/v1/authenticate')
+            .reply(201, m_alMock.AIMS_RESPONSE_200);
+        
+        var aimsc = new m_alService.AimsC(
+                m_alMock.AL_API, m_alMock.AIMS_CREDS, '/tmp');
+        aimsc.authenticate()
+            .then(resp => {
+                assert.equal(resp.authentication.user.name, 'user-name');
+                return done();
+            });
+    });
+    
+    it('Retry errno with default retry config', function(done) {
+        this.timeout(4000);
+        var aimsMock = nock('https://' + m_alMock.AL_API)
+            .post('/aims/v1/authenticate')
+            .replyWithError({errno: 'ENOTFOUND'})
+            .post('/aims/v1/authenticate')
+            .reply(201, m_alMock.AIMS_RESPONSE_200);
+        
+        var aimsc = new m_alService.AimsC(
+                m_alMock.AL_API, m_alMock.AIMS_CREDS, '/tmp');
+        aimsc.authenticate()
+            .then(resp => {
+                assert.equal(resp.authentication.user.name, 'user-name');
+                return done();
+            });
+    });
+    
+    it('Do not retry 4XX with default retry config', function(done) {
+        var aimsMock = nock('https://' + m_alMock.AL_API)
+            .post('/aims/v1/authenticate')
+            .reply(401, {statusCode: 401})
+            .post('/aims/v1/authenticate')
+            .reply(201, m_alMock.AIMS_RESPONSE_200);
+        
+        var aimsc = new m_alService.AimsC(
+                m_alMock.AL_API, m_alMock.AIMS_CREDS, '/tmp');
+        
+        aimsc.authenticate()
+            .then(resp => {
+                assert.equal(true, 'Expecting 401');
+                return done();
+            })
+            .catch(err => {
+                assert.equal(err.statusCode, 401);
+                return done();
+            });
+    });
+    
+    it('Test custom retry callback gets called on 200', function(done) {
+        var customRetryCode = 111;
+        var aimsMock = nock('https://' + m_alMock.AL_API)
+            .post('/aims/v1/authenticate')
+            .reply(200, {retryCode: customRetryCode})
+            .post('/aims/v1/authenticate')
+            .reply(201, m_alMock.AIMS_RESPONSE_200);
+        var customRetry = function(resp) {
+            if (resp.retryCode == customRetryCode) {
+                return true;
+            } else {
+                return false;
+            }
+        };
+        var retryOptions = {
+                minTimeout: 500,
+                retries: 1,
+                retryCb: customRetry
+            };
+        
+        var aimsc = new m_alService.AimsC(
+                m_alMock.AL_API, m_alMock.AIMS_CREDS, '/tmp', retryOptions);
+        
+        aimsc.authenticate()
+            .then(resp => {
+                assert.equal(resp.authentication.user.name, 'user-name');
+                return done();
+            });
+    });
+    
+    it('Test custom retry callback gets called on error', function(done) {
+        var customRetryCode = 'ECUSTOM';
+        var aimsMock = nock('https://' + m_alMock.AL_API)
+            .post('/aims/v1/authenticate')
+            .replyWithError({customError: customRetryCode})
+            .post('/aims/v1/authenticate')
+            .reply(201, m_alMock.AIMS_RESPONSE_200);
+        var customRetry = function(resp) {
+            if (resp.error.customError == customRetryCode) {
+                return false;
+            } else {
+                return true;
+            }
+        };
+        var retryOptions = {
+                minTimeout: 500,
+                retries: 1,
+                retryCb: customRetry
+            };
+        
+        var aimsc = new m_alService.AimsC(
+                m_alMock.AL_API, m_alMock.AIMS_CREDS, '/tmp', retryOptions);
+        
+        aimsc.authenticate()
+            .then(resp => {
+                assert.equal(true, 'Expecting an error to happen.');
+                return done();
+            })
+            .catch(err =>{
+                assert.equal(err.error.customError, customRetryCode);
+                return done();
+            });
+    });
+});


### PR DESCRIPTION
### Solution Description
The following features are added:
* precompiled protobuf definitions for log data type.
* helper function `al_log:buildPayload()` for converting incoming log messages to protobuf payloads ready to be transfered to Ingestion service.
* HTTP request retry options. By default, two times retry for  5XX responses and system level errors.

