### PR TITLE
No retries fro 204

### DIFF
--- a/al_util.js
+++ b/al_util.js
@@ -31,8 +31,9 @@ let DEFAULT_RETRY = {
  *  Keeps retrying 5XX HTTP responses and any system level errors
  **/
 var defaultRetryCb = function(err){
-    if (err.statusCode >= 500 ||
-        (err.error && err.error.errno)) {
+    if (err && 
+        (err.statusCode >= 500 ||
+        (err.error && err.error.errno))) {
         return true;
     } else {
         return false;

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
     "timekeeper": "^2.1.2"
   },
   "dependencies": {
-    "async": "*",
-    "debug": "*",
+    "async": "^2.6.1",
+    "debug": "^4.1.0",
     "moment": "^2.19.2",
     "protobufjs": "^6.8.8",
-    "request": "*",
-    "request-promise-native": "*",
+    "request": "^2.88.0",
+    "request-promise-native": "^1.0.5",
     "retry": "^0.12.0"
   },
   "author": "Alert Logic Inc."


### PR DESCRIPTION
### Problem Description
If service replies with 204 No Content a collector fails with
```
Unhandled promise rejection (rejection id: 1): TypeError: Cannot read property 'statusCode' of undefined
```

### Solution Description
Have no retries for 204.
Fix dependency versions.

@mtrybulec

