### PR TITLE
Add eqeqeq to .jshintrc; drop unused parameters in sendVpcFlow and sendAicspmsgs

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,5 @@
 {
+  "eqeqeq": true,
   "esversion": 6,
   "mocha": true,
   "node": true

--- a/al_servicec.js
+++ b/al_servicec.js
@@ -178,7 +178,7 @@ class IngestC extends AlServiceC {
         return this.post(`/data/secmsgs`, payload);
     }
 
-    sendVpcFlow(data, invokedBy) {
+    sendVpcFlow(data) {
         'use strict';
         let payload = {
             json : false,
@@ -193,7 +193,7 @@ class IngestC extends AlServiceC {
         return this.post(`/data/vpcflow`, payload);
     }
     
-    sendAicspmsgs(data, invokedBy) {
+    sendAicspmsgs(data) {
         'use strict';
         let payload = {
             json : false,

--- a/test/aimsc_test.js
+++ b/test/aimsc_test.js
@@ -31,9 +31,9 @@ describe('Unit Tests', function() {
 
             fakeRest = sinon.stub(RestServiceClient.prototype, 'post').callsFake(
                 function fakeFn(path, options) {
-                    if (path == '/aims/v1/authenticate' &&
-                        options.auth.user == m_alMock.AIMS_AUTH.auth.user &&
-                        options.auth.password == m_alMock.AIMS_AUTH.auth.password) {
+                    if (path === '/aims/v1/authenticate' &&
+                        options.auth.user === m_alMock.AIMS_AUTH.auth.user &&
+                        options.auth.password === m_alMock.AIMS_AUTH.auth.password) {
                         return new Promise(function(resolve, reject) {
                             resolve(m_alMock.gen_auth_response());
                         });

--- a/test/al_log_test.js
+++ b/test/al_log_test.js
@@ -55,7 +55,7 @@ describe('Unit Tests', function() {
             };
             var expectedPayload = 'eJzjamHi4izOLy1KTtXNTBGK5mLPyC8uATFFdm6e97ZBfLqW665Nbkkbdic+E771WoJByYJLhosvJz85MScepDQvMTdViEuKozg/NxXE5pLg4gSJx5dUFqQKcUtxJlaVFqXGp5XmSfkIHtV4Hc0ABLLcQEKJO9/YzLQ8NSkjPz/biCM3tbg4MT3V0Io/qzg/Tx+sTQ+kwknEEcR2TC7JLEt1ySxKTS7JL6okzjQjIk0DAFuCVYc=';
             alLog.buildPayload('host-id', 'source-id', hml, msgs, parseFun, function(err, payload){
-                assert.equal(expectedPayload, new Buffer(payload).toString('base64'));
+                assert.equal(expectedPayload, payload.toString('base64'));
                 return done();
             });
         });

--- a/test/alservicec_test.js
+++ b/test/alservicec_test.js
@@ -26,9 +26,9 @@ describe('Unit Tests', function() {
             fakeAims = sinon.stub(RestServiceClient.prototype, 'post');
             fakeAims.callsFake(
                 function fakeFn(path, options) {
-                    if (path == '/aims/v1/authenticate' &&
-                        options.auth.user == m_alMock.AIMS_AUTH.auth.user &&
-                        options.auth.password == m_alMock.AIMS_AUTH.auth.password) {
+                    if (path === '/aims/v1/authenticate' &&
+                        options.auth.user === m_alMock.AIMS_AUTH.auth.user &&
+                        options.auth.password === m_alMock.AIMS_AUTH.auth.password) {
                         return new Promise(function(resolve, reject) {
                             resolve(m_alMock.gen_auth_response());
                         });

--- a/test/request_retry_test.js
+++ b/test/request_retry_test.js
@@ -147,7 +147,7 @@ describe('HTTP request retry tests', function() {
             .post('/aims/v1/authenticate')
             .reply(201, m_alMock.AIMS_RESPONSE_200);
         var customRetry = function(resp) {
-            if (resp.retryCode == customRetryCode) {
+            if (resp.retryCode === customRetryCode) {
                 return true;
             } else {
                 return false;
@@ -177,7 +177,7 @@ describe('HTTP request retry tests', function() {
             .post('/aims/v1/authenticate')
             .reply(201, m_alMock.AIMS_RESPONSE_200);
         var customRetry = function(resp) {
-            if (resp.error.customError == customRetryCode) {
+            if (resp.error.customError === customRetryCode) {
                 return false;
             } else {
                 return true;


### PR DESCRIPTION
### Problem Description
eqeqeq missing from .jshintrc

### Solution Description
Added eqeqeq to .jshintrc; removed unused parameters in sendVpcFlow and sendAicspmsgs, simplified payload checking code

