### PR TITLE
Do not pass redundant Azure parameters in reg/redeg/checkin body.

### DIFF
--- a/azcollectc.js
+++ b/azcollectc.js
@@ -147,7 +147,7 @@ class AzcollectC extends AlServiceC {
         delete deregBody.subscription_id;
         delete deregBody.web_app_name;
         return this.deleteRequest(`/azure/${collectorType}/` +
-            `${deregInput.subscription_id}/${deregInput.app_resource_group}/${functionName}`);
+            `${deregInput.subscription_id}/${deregInput.app_resource_group}/${functionName}`, {body: deregBody});
     }
     
     _doSendCheckin(checkinUrl, checkinBody) {

--- a/azcollectc.js
+++ b/azcollectc.js
@@ -113,30 +113,41 @@ class AzcollectC extends AlServiceC {
              `${registrationValues.awsAccountId}/${registrationValues.region}/${functionName}`);
      }
     
-    _doCheckinAzure(checkinBody) {
+    _doCheckinAzure(checkinInput) {
         'use strict';
+        var checkinBody = Object.assign({}, checkinInput);
         const type = this._collectorType;
         var functionName = encodeURIComponent(checkinBody.web_app_name);
-        var checkinUrl = `/azure/${type}/checkin/${checkinBody.subscription_id}/` +
-                         `${checkinBody.app_resource_group}/${functionName}`;
+        var checkinUrl = `/azure/${type}/checkin/${checkinInput.subscription_id}/` +
+                         `${checkinInput.app_resource_group}/${functionName}`;
+        delete checkinBody.app_resource_group;
+        delete checkinBody.subscription_id;
+        delete checkinBody.web_app_name;
         return this._doSendCheckin(checkinUrl, checkinBody);
     }
     
-    _doRegistrationAzure(regBody) {
+    _doRegistrationAzure(regInput) {
         'use strict';
-         const collectorType = this._collectorType;
-         const functionName = encodeURIComponent(regBody.web_app_name);
-         
-         return this.post(`/azure/${collectorType}/` +
-             `${regBody.subscription_id}/${regBody.app_resource_group}/${functionName}`, {body: regBody});
+        var regBody = Object.assign({}, regInput);
+        const collectorType = this._collectorType;
+        const functionName = encodeURIComponent(regInput.web_app_name);
+        delete regBody.app_resource_group;
+        delete regBody.subscription_id;
+        delete regBody.web_app_name;
+        return this.post(`/azure/${collectorType}/` +
+                `${regInput.subscription_id}/${regInput.app_resource_group}/${functionName}`, {body: regBody});
     }
     
-    _doDeregistrationAzure(deregBody) {
+    _doDeregistrationAzure(deregInput) {
         'use strict';
+        var deregBody = Object.assign({}, deregInput);
         const collectorType = this._collectorType;
         var functionName = encodeURIComponent(deregBody.web_app_name);
+        delete deregBody.app_resource_group;
+        delete deregBody.subscription_id;
+        delete deregBody.web_app_name;
         return this.deleteRequest(`/azure/${collectorType}/` +
-            `${deregBody.subscription_id}/${deregBody.app_resource_group}/${functionName}`);
+            `${deregInput.subscription_id}/${deregInput.app_resource_group}/${functionName}`);
     }
     
     _doSendCheckin(checkinUrl, checkinBody) {

--- a/test/azcollectc_test.js
+++ b/test/azcollectc_test.js
@@ -189,7 +189,7 @@ describe('Unit Tests', function() {
         it('Azure register', function(done) {
             var aimsc = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
             var azc = new AzcollectC(m_alMock.INGEST_ENDPOINT, aimsc, 'o365');
-            var expectedChekinBody = {
+            var expectedRegisterBody = {
                 body: {
                     app_tenant_id: 'azure-tenant-id',
                     client_id: 'azure-client-id',
@@ -204,7 +204,7 @@ describe('Unit Tests', function() {
             
             azc.register(m_alMock.AZURE_REGISTER_VALUES).then( resp => {
                 sinon.assert.calledWith(fakePost, '/azure/o365/azure-subscription-id/azure-resource-group/azure-web-app-name',
-                        expectedChekinBody);
+                        expectedRegisterBody);
                 
                 done();
             });
@@ -216,12 +216,20 @@ describe('Unit Tests', function() {
             const deregValues = {
                 web_app_name : 'azure-web-app-name',
                 app_tenant_id : 'azure-tenant-id',
+                source_id: 'source-id',
                 app_resource_group : 'azure-resource-group',
                 subscription_id : 'azure-subscription-id',
             };
             
+            const expectedDeregBody = {
+                body: {
+                    app_tenant_id : 'azure-tenant-id',
+                    source_id: 'source-id'
+                }
+            };
+            
             azc.deregister(deregValues).then( resp => {
-                sinon.assert.calledWith(fakeDel, '/azure/ehub/azure-subscription-id/azure-resource-group/azure-web-app-name');
+                sinon.assert.calledWith(fakeDel, '/azure/ehub/azure-subscription-id/azure-resource-group/azure-web-app-name', expectedDeregBody);
                 done();
             });
         });

--- a/test/azcollectc_test.js
+++ b/test/azcollectc_test.js
@@ -191,7 +191,6 @@ describe('Unit Tests', function() {
             var azc = new AzcollectC(m_alMock.INGEST_ENDPOINT, aimsc, 'o365');
             var expectedChekinBody = {
                 body: {
-                    app_resource_group: 'azure-resource-group',
                     app_tenant_id: 'azure-tenant-id',
                     client_id: 'azure-client-id',
                     client_secret: 'azure-client-secret',
@@ -199,9 +198,7 @@ describe('Unit Tests', function() {
                       content_streams: '[\"Audit.AzureActiveDirectory\", \"Audit.Exchange\", \"Audit.SharePoint\", \"Audit.General\"]',
                       type: 'o365'
                     },
-                    subscription_id: 'azure-subscription-id',
-                    version: '1.0.0',
-                    web_app_name: 'azure-web-app-name'
+                    version: '1.0.0'
                 }
             };
             
@@ -233,7 +230,14 @@ describe('Unit Tests', function() {
             var aimsc = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
             var azc = new AzcollectC(m_alMock.INGEST_ENDPOINT, aimsc, 'ehub', false);
             var expectedCheckinBody = {
-                    body: m_alMock.AZURE_CHECKIN_VALUES
+                    body: {
+                        version : '1.0.0',
+                        app_tenant_id : 'azure-tenant-id',
+                        status: 'ok',
+                        error_code: undefined,
+                        details: [],
+                        statistics: undefined
+                    }
             };
             azc.checkin(m_alMock.AZURE_CHECKIN_VALUES).then( resp => {
                 sinon.assert.calledWith(
@@ -248,7 +252,16 @@ describe('Unit Tests', function() {
             var aimsc = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
             var azc = new AzcollectC(m_alMock.INGEST_ENDPOINT, aimsc, 'ehub', true);
             
-            var expectedCompressedBody = zlib.deflateSync(JSON.stringify(m_alMock.AZURE_CHECKIN_VALUES));
+            var expectedCheckin = {
+                version : '1.0.0',
+                app_tenant_id : 'azure-tenant-id',
+                status: 'ok',
+                error_code: undefined,
+                details: [],
+                statistics: undefined
+            };
+            
+            var expectedCompressedBody = zlib.deflateSync(JSON.stringify(expectedCheckin));
             var expectedCheckinBody = {
                 json : false,
                 headers : {


### PR DESCRIPTION
### Solution Description
Some parameters (subscription id, resource group, function name) in register/deregister/checkin body for Azure collectors are redundant. These parameters are passed in the HTTP request URL and can be removed.
