### PR TITLE
check for zero in getProp

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-collector-js",
-  "version": "1.1.2",
+  "version": "1.2.2",
   "license": "MIT",
   "description": "Alert Logic Collector Common Library",
   "repository": {

--- a/parse.js
+++ b/parse.js
@@ -18,7 +18,7 @@ const ISO8601_MICROSEC_OFFSET = 20;
 
 var getProp = function(path, obj, defaultVal = null) {
     var reduceFun = function(xs, x) {
-        return (xs && xs[x]) ? xs[x] : defaultVal;
+        return (xs && (xs[x] || xs[x] === 0)) ? xs[x] : defaultVal;
     };
     return path.reduce(reduceFun, obj);
 };

--- a/test/parse_test.js
+++ b/test/parse_test.js
@@ -42,6 +42,21 @@ describe('Common parse functions unit tests.', function() {
         
         done();
     });
+
+    it('Zero at key', function(done) {
+        var privGetProp = parseWire.__get__('getProp');
+        var obj = {
+            a: {
+                aa: 1,
+                ab: 2
+            },
+            b: 0,
+            c: 3
+        };
+        assert.equal(privGetProp(['b'], obj), 0);
+        
+        done();
+    });
     
     it('Empty path', function(done) {
         var privGetProp = parseWire.__get__('getProp');


### PR DESCRIPTION
### Problem Description
`getProp` function would skip over fields that were zero. even if they exist becuase 0 is falsy in JS

### Solution Description
Chekc for truthy or 0 in the function.

