### PR TITLE
Simply pass entire input as register body for AWS collectors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ clean:
 	rm -rf ./coverage/
 
 publish:
-	npm run publish
+	npm run rel
 
 pb: $(PROTO_DIR)
 	cd $(PROTO_DIR) && make compile

--- a/azcollectc.js
+++ b/azcollectc.js
@@ -96,15 +96,10 @@ class AzcollectC extends AlServiceC {
 
     _doRegistrationAws(registrationValues) {
         'use strict';
-        let regBody = Object.assign({
-             cf_stack_name : registrationValues.stackName,
-             version : registrationValues.version,
-             data_type : registrationValues.dataType ? registrationValues.dataType : 'secmsgs'
-        }, registrationValues.custom_fields);
         const type = this._collectorType;
         var functionName = encodeURIComponent(registrationValues.functionName);
         return this.post(`/aws/${type}/` +
-            `${registrationValues.awsAccountId}/${registrationValues.region}/${functionName}`, {body: regBody});
+            `${registrationValues.awsAccountId}/${registrationValues.region}/${functionName}`, {body: registrationValues});
     }
 
      _doDeregistrationAws(registrationValues) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-collector-js",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "license": "MIT",
   "description": "Alert Logic Collector Common Library",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "lint": "jshint --show-non-errors --exclude \"./node_modules/*,./proto/*\" **/*.js *.js",
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=cobertura mocha --colors --reporter mocha-jenkins-reporter",
-    "publish": "npm publish --access=public"
+    "rel": "npm publish --access=public"
   },
   "main": "index.js",
   "maintainers": [

--- a/test/azcollectc_test.js
+++ b/test/azcollectc_test.js
@@ -63,19 +63,23 @@ describe('Unit Tests', function() {
                 functionName : 'test-function',
                 region : 'us-east-1',
                 version : '1.0.0',
-                stackName : 'test-stack'
-                
+                stackName : 'test-stack',
+                cf_stack_name: "test-stack",
+                data_type: "secmsgs"
             };
             azc.register(checkinValues).then( resp => {
                 sinon.assert.calledWith(fakePost, '/aws/cwe/1234567890/us-east-1/test-function',
                     { 
                         body: {
-                            cf_stack_name: 'test-stack',
-                            data_type: 'secmsgs',
-                            version: '1.0.0'
+                            awsAccountId: "1234567890",
+                            cf_stack_name: "test-stack",
+                            data_type: "secmsgs",
+                            functionName: "test-function",
+                            region: "us-east-1",
+                            stackName: "test-stack",
+                            version: "1.0.0"
                         }
                     });
-                
                 done();
             });
         });
@@ -97,15 +101,51 @@ describe('Unit Tests', function() {
                 sinon.assert.calledWith(fakePost, '/aws/cwl/1234567890/us-east-1/test-function',
                     { 
                         body: {
-                            cf_stack_name: 'test-stack',
-                            data_type: 'vpcflow',
-                            version: '1.0.0'
+                            awsAccountId: "1234567890",
+                            dataType: "vpcflow",
+                            functionName: "test-function",
+                            region: "us-east-1",
+                            stackName: "test-stack",
+                            version: "1.0.0"
                         }
                     });
                 done();
             });
         });
-        
+
+        it('AWS register with custom_fields', function(done) {
+            var aimsc = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
+            var azc = new AzcollectC(m_alMock.INGEST_ENDPOINT, aimsc, 'cwl');
+            
+            const checkinValues = {
+                awsAccountId : '1234567890',
+                functionName : 'test-function',
+                region : 'us-east-1',
+                version : '1.0.0',
+                stackName : 'test-stack',
+                dataType: 'vpcflow',
+                custom_fields: {
+                    some: 'custom_field'
+                }
+                
+            };
+            azc.register(checkinValues).then( resp => {
+                sinon.assert.calledWith(fakePost, '/aws/cwl/1234567890/us-east-1/test-function',
+                    { 
+                        body: {
+                            awsAccountId: "1234567890",
+                            custom_fields: { some: "custom_field" },
+                            dataType: "vpcflow",
+                            functionName: "test-function",
+                            region: "us-east-1",
+                            stackName: "test-stack",
+                            version: "1.0.0"
+                        }
+                    });
+                done();
+            });
+        });
+
         it('AWS deregister', function(done) {
             var aimsc = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
             var azc = new AzcollectC(m_alMock.INGEST_ENDPOINT, aimsc, 'cwe');


### PR DESCRIPTION
### Solution Description
Simplify Azcollectc `register()` for AWS collector by passing through `registrationValue` as registration body.