### PR TITLE
Pass azcollect/checkin properties as is for AWS collectors

### DIFF
--- a/azcollectc.js
+++ b/azcollectc.js
@@ -80,18 +80,11 @@ class AzcollectC extends AlServiceC {
 
     _doCheckinAws(checkinValues) {
         'use strict';
-        let checkinBody = {
-            version : checkinValues.version,
-            status : checkinValues.status,
-            error_code : checkinValues.error_code,
-            details : checkinValues.details,
-            statistics : checkinValues.statistics
-        };
         const type = this._collectorType;
         var functionName = encodeURIComponent(checkinValues.functionName);
         var checkinUrl = `/aws/${type}/checkin/${checkinValues.awsAccountId}/` +
                          `${checkinValues.region}/${functionName}`;
-        return this._doSendCheckin(checkinUrl, checkinBody);
+        return this._doSendCheckin(checkinUrl, checkinValues);
     }
 
     _doRegistrationAws(registrationValues) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-collector-js",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "description": "Alert Logic Collector Common Library",
   "repository": {

--- a/test/al_mock.js
+++ b/test/al_mock.js
@@ -70,6 +70,9 @@ const AZURE_CHECKIN_VALUES = {
 
 const AZCOLLECT_CHECKIN_QUERY = {
     body : {
+        awsAccountId: '1234567890',
+        functionName: 'test-function',
+        region: 'us-east-1',
         version: '1.0.0',
         status: 'ok',
         error_code: undefined,


### PR DESCRIPTION
Pass checkin values as is in order to allow collectors to add any properties and have collector specific checkin requests.
