### PR TITLE
Pass AWS collector properties for deregistration

### DIFF
--- a/azcollectc.js
+++ b/azcollectc.js
@@ -100,7 +100,7 @@ class AzcollectC extends AlServiceC {
          const type = this._collectorType;
          var functionName = encodeURIComponent(registrationValues.functionName);
          return this.deleteRequest(`/aws/${type}/` +
-             `${registrationValues.awsAccountId}/${registrationValues.region}/${functionName}`);
+             `${registrationValues.awsAccountId}/${registrationValues.region}/${functionName}`, {body: registrationValues});
      }
     
     _doCheckinAzure(checkinInput) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-collector-js",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "license": "MIT",
   "description": "Alert Logic Collector Common Library",
   "repository": {

--- a/test/azcollectc_test.js
+++ b/test/azcollectc_test.js
@@ -156,7 +156,10 @@ describe('Unit Tests', function() {
             };
             
             azc.deregister(checkinValues).then( resp => {
-                sinon.assert.calledWith(fakeDel, '/aws/cwe/1234567890/us-east-1/test-function');
+                sinon.assert.calledWith(fakeDel, '/aws/cwe/1234567890/us-east-1/test-function',
+                    { 
+                        body: checkinValues
+                    });
                 done();
             });
         });


### PR DESCRIPTION
### Solution Description
Allow collector to pass its properties during deregistration.
