### PR TITLE
catch unsuccessful removal of token cache

### DIFF
--- a/al_servicec.js
+++ b/al_servicec.js
@@ -84,11 +84,13 @@ class AimsC extends m_alUtil.RestServiceClient {
                 return true;
             }
         } catch (e) {
-            if (e instanceof SyntaxError ||
-               ((e instanceof Error) && e.code !== 'ENOENT')) {
-                fs.unlinkSync(filename);
+            try {
+                if (e instanceof SyntaxError || ((e instanceof Error) && e.code !== 'ENOENT')) {
+                    fs.unlinkSync(filename);
+                }
             }
-            return false;
+            catch (err) { }
+            return false;    
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-collector-js",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "description": "Alert Logic Collector Common Library",
   "repository": {


### PR DESCRIPTION
### Problem Description
- crashes on unsuccessful removal of token cache cause collection to fail:

```
{
    "errorType": "Error",
    "errorMessage": "ENOENT: no such file or directory, unlink '/tmp/e42fa7bf7cde2ee5-token.tmp'",
    "code": "ENOENT",
    "errno": -2,
    "syscall": "unlink",
    "path": "/tmp/e42fa7bf7cde2ee5-token.tmp",
    "stack": [
        "Error: ENOENT: no such file or directory, unlink '/tmp/e42fa7bf7cde2ee5-token.tmp'",
        "    at Object.unlinkSync (fs.js:1136:3)",
        "    at AimsC._isTokenFileCached (/var/task/node_modules/@alertlogic/al-aws-collector-js/node_modules/@alertlogic/al-collector-js/al_servicec.js:89:20)",
        "    at AimsC._makeAuthRequest (/var/task/node_modules/@alertlogic/al-aws-collector-js/node_modules/@alertlogic/al-collector-js/al_servicec.js:49:18)",
        "    at AimsC.authenticate (/var/task/node_modules/@alertlogic/al-aws-collector-js/node_modules/@alertlogic/al-collector-js/al_servicec.js:101:21)",
        "    at IngestC.request (/var/task/node_modules/@alertlogic/al-aws-collector-js/node_modules/@alertlogic/al-collector-js/al_servicec.js:127:28)",
        "    at IngestC.post (/var/task/node_modules/@alertlogic/al-aws-collector-js/node_modules/@alertlogic/al-collector-js/al_util.js:119:21)",
        "    at IngestC.sendAgentstatus (/var/task/node_modules/@alertlogic/al-aws-collector-js/node_modules/@alertlogic/al-collector-js/ingestc.js:84:21)",
        "    at Deflate.cb (/var/task/node_modules/@alertlogic/al-aws-collector-js/al_aws_collector.js:507:48)",
        "    at Deflate.zlibBufferOnEnd (zlib.js:149:10)",
        "    at Deflate.emit (events.js:327:22)"
    ]
}
```

### Solution Description
- catch and dump the exception 

