### PR TITLE
log cache unlink failures

### DIFF
--- a/al_servicec.js
+++ b/al_servicec.js
@@ -85,16 +85,16 @@ class AimsC extends m_alUtil.RestServiceClient {
             }
         } catch (e) {
             try {
-                if (e instanceof SyntaxError || ((e instanceof Error)
-                    && e.code !== 'ENOENT'
-                    && e.code !== 'EMFILE' 
+                if (e instanceof SyntaxError || ((e instanceof Error) && 
+                e.code !== 'ENOENT' && 
+                e.code !== 'EMFILE' 
                 )) {
                     fs.unlinkSync(filename);
                 }
-                return false
+                return false;
             }
             catch (err) {
-                console.error(`Failed to unlink cache due to: ${err}, cache read failure: ${e}`);
+                console.error(`Failed to unlink cache due to: ${err}, cache read failure: ${e}, file name: ${filename}`);
                 return false;
             }
         }

--- a/al_servicec.js
+++ b/al_servicec.js
@@ -85,12 +85,18 @@ class AimsC extends m_alUtil.RestServiceClient {
             }
         } catch (e) {
             try {
-                if (e instanceof SyntaxError || ((e instanceof Error) && e.code !== 'ENOENT')) {
+                if (e instanceof SyntaxError || ((e instanceof Error)
+                    && e.code !== 'ENOENT'
+                    && e.code !== 'EMFILE' 
+                )) {
                     fs.unlinkSync(filename);
                 }
+                return false
             }
-            catch (err) { }
-            return false;    
+            catch (err) {
+                console.error(`Failed to unlink cache due to: ${err}, cache read failure: ${e}`);
+                return false;
+            }
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-collector-js",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "license": "MIT",
   "description": "Alert Logic Collector Common Library",
   "repository": {


### PR DESCRIPTION
### Problem Description
- removal of cache file when expired can throw an ENOENT failure, due to cases where the file may not exist 

### Solution Description
- catch this error and log the issue for future debugging

