### PR TITLE
ENG-25186 :Added the sendLmcstats method to post the lmc stats to ingest

### DIFF
--- a/ingestc.js
+++ b/ingestc.js
@@ -83,6 +83,20 @@ class IngestC extends AlServiceC {
         };
         return this.post(`/data/agentstatus`, payload);
     }
+
+    sendLmcstats(data) {
+        let payload = {
+            json : false,
+            headers : {
+                'Content-Type': 'alertlogic.com/json',
+                'x-invoked-by' : this._functionType,
+                'Content-Encoding' : 'deflate',
+                'Content-Length' : Buffer.byteLength(data)
+            },
+            body : data
+        };
+        return this.post(`/data/lmcstats`, payload);
+    }
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-collector-js",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "MIT",
   "description": "Alert Logic Collector Common Library",
   "repository": {


### PR DESCRIPTION
This method send the lmc stats for PAWS, ehub, legacy o365 and s3 collectors.

