### PR TITLE
Embedded log filters

### DIFF
--- a/al_log.js
+++ b/al_log.js
@@ -3,7 +3,7 @@
  * @doc
  *
  * Helper utilities for  Alert Logic log collector.
- * NOT: parametersto all function are passed as (object, callback)
+ * NOT: parameters to all functions are passed as (object, callback)
  *
  * @end
  * -----------------------------------------------------------------------------

--- a/al_log.js
+++ b/al_log.js
@@ -3,7 +3,7 @@
  * @doc
  *
  * Helper utilities for  Alert Logic log collector.
- * NOT: parameters to all functions are passed as (object, callback)
+ * NOTE: parameters to all functions are passed as (object, callback)
  *
  * @end
  * -----------------------------------------------------------------------------
@@ -70,7 +70,9 @@ var buildPayload = function ({hostId, sourceId, hostmetaElems, content, parseCal
         function(callback) {
             const params = {
                 content: content,
-                parseContentFun: parseCallback
+                parseContentFun: parseCallback,
+                filterJson: filterJson,
+                filterRegexp: filterRegexp
             };
             buildMessages(params, function(err, msg) {
                 return callback(err, msg);

--- a/al_log_filter.js
+++ b/al_log_filter.js
@@ -1,0 +1,56 @@
+/* -----------------------------------------------------------------------------
+ * @copyright (C) 2021, Alert Logic, Inc
+ * @doc
+ *
+ * Helper log filter utilities for  Alert Logic log collector.
+ *
+ * @end
+ * -----------------------------------------------------------------------------
+ */
+const where = require('lodash.where');
+
+/**
+ *  @function filter messages using JSON like filters.
+ *  
+ *  @param messages - array of JSON parsed log messages
+ *  @param filterString - filter string, for example, '{user: \"a\"}'
+ *  
+ *  @return array - filtered messages
+ *  @NOTE: If json filter  is bad then 'messages' is returned unfiltered.
+ */
+
+var filterJson = function (messages, filterString) {
+    
+    try {
+        const filterJ = JSON.parse(filterString);
+        return where(messages, filterJ);
+    }
+    catch (exception) {
+        return messages;
+    }
+};
+
+/**
+ *  @function filters messages using regexp
+ *  
+ *  @param messages - array of JSON parsed log messages
+ *  @param filterRegExp - filter string regexp, for example, 'ab+c'
+ *  
+ *  @return array - filtered messages
+ *  @NOTE: If regexp filter is bad then 'messages' is returned unfiltered.
+ */
+
+var filterRegExp = function (messages, regExp) {
+    try {
+        const re = new RegExp(regExp);
+        return messages.filter(function(m) { return re.test(m); });
+    } catch (exception) {
+        return messages;
+    }
+};
+
+module.exports = {
+    filterJson : filterJson,
+    filterRegExp : filterRegExp
+};
+

--- a/al_log_filter.js
+++ b/al_log_filter.js
@@ -10,23 +10,59 @@
 const where = require('lodash.where');
 
 /**
+ *  @function initializes JSON filter
+ *  
+ *  @param filter - string or object, for example, '{"a": 1}', {a:1}
+ *  
+ *  @return filter - inited Json filter or null if json is incorrect
+ */
+var initJsonFilter = function(filter) {
+    if (typeof filter === 'string') {
+        try {
+            return JSON.parse(filter);
+        } catch (exception) {
+            return null;
+        }
+    } else {
+        return filter;
+    }
+};
+
+/**
  *  @function filter messages using JSON like filters.
  *  
  *  @param messages - array of JSON parsed log messages
- *  @param filterString - filter string, for example, '{user: \"a\"}'
+ *  @param filterString - filter string/object, for example, '{user: \"a\"}'
  *  
  *  @return array - filtered messages
  *  @NOTE: If json filter  is bad then 'messages' is returned unfiltered.
  */
 
-var filterJson = function (messages, filterString) {
-    
-    try {
-        const filterJ = JSON.parse(filterString);
+var filterJson = function(messages, filter) {
+    const filterJ = initJsonFilter(filter);
+    if (filterJ) {
         return where(messages, filterJ);
-    }
-    catch (exception) {
+    } else {
         return messages;
+    }
+};
+
+/**
+ *  @function initializes reg exp filter
+ *  
+ *  @param filter - string or regexp, for example, 'ab+c', /ab+c/
+ *  
+ *  @return filter - inited regexp or null if regexp is incorrect
+ */
+var initRegExpFilter = function(filter) {
+    if (typeof filter === 'string') {
+        try {
+            return new RegExp(filter);
+        } catch (exception) {
+            return null;
+        }
+    } else {
+        return filter;
     }
 };
 
@@ -34,23 +70,26 @@ var filterJson = function (messages, filterString) {
  *  @function filters messages using regexp
  *  
  *  @param messages - array of JSON parsed log messages
- *  @param filterRegExp - filter string regexp, for example, 'ab+c'
+ *  @param filter - filter string regexp or regexp object, for example, 'ab+c', /ab+c/
  *  
  *  @return array - filtered messages
  *  @NOTE: If regexp filter is bad then 'messages' is returned unfiltered.
  */
 
-var filterRegExp = function (messages, regExp) {
-    try {
-        const re = new RegExp(regExp);
+var filterRegExp = function(messages, filter) {
+    const re = initRegExpFilter(filter);
+    if (re) {
         return messages.filter(function(m) { return re.test(m); });
-    } catch (exception) {
+    } else {
         return messages;
     }
 };
 
+
 module.exports = {
     filterJson : filterJson,
-    filterRegExp : filterRegExp
+    filterRegExp : filterRegExp,
+    initRegExpFilter : initRegExpFilter,
+    initJsonFilter : initJsonFilter
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-collector-js",
-  "version": "2.0.5",
+  "version": "3.0.0",
   "license": "MIT",
   "description": "Alert Logic Collector Common Library",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-collector-js",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "license": "MIT",
   "description": "Alert Logic Collector Common Library",
   "repository": {
@@ -32,6 +32,7 @@
   "dependencies": {
     "async": "3.1.0",
     "debug": "4.1.1",
+    "lodash.where": "^3.1.0",
     "moment": "2.24.0",
     "protobufjs": "6.8.8",
     "request": "2.88.0",

--- a/test/al_log_filter_test.js
+++ b/test/al_log_filter_test.js
@@ -43,5 +43,16 @@ describe('Unit Tests', function() {
             return done();
         });
         
+        it('Wrong RegExp filter', function(done) {
+            assert.deepEqual(msgString, alLogFilter.filterRegExp(msgString, '['));
+            return done();
+        });
+        
+        it('Undefined filters', function(done) {
+            assert.deepEqual(msgString, alLogFilter.filterRegExp(msgString, null));
+            assert.deepEqual(msgJson, alLogFilter.filterJson(msgJson));
+            return done();
+        });
+        
     });
 });

--- a/test/al_log_filter_test.js
+++ b/test/al_log_filter_test.js
@@ -1,0 +1,47 @@
+/* -----------------------------------------------------------------------------
+ * @copyright (C) 2021, Alert Logic, Inc
+ * @doc
+ *
+ * Tests for log filtering.
+ *
+ * @end
+ * -----------------------------------------------------------------------------
+ */
+
+const assert = require('assert');
+const alLogFilter = require('../al_log_filter');
+
+
+describe('Unit Tests', function() {
+    describe('Filter Messages', function() {
+        
+        const msgJson = [
+            { message1: 1, text: 'test1' },
+            { message2: 2, text: 'test12'},
+            { messageA: "a", text: 'testa'},
+        ];
+        const msgString = [
+            'message1',
+            'message2',
+            'message3'
+        ];
+        
+        before(function(){
+        });
+        after(function() {
+        });
+
+        it('Sunny case ', function(done) {
+            assert.deepEqual([{ message1: 1, text: 'test1' }], alLogFilter.filterJson(msgJson, '{"message1":1}'));
+            assert.deepEqual(['message1'], alLogFilter.filterRegExp(msgString, '.*1'));
+            assert.deepEqual(['message1', 'message2', 'message3'], alLogFilter.filterRegExp(msgString, '^message.*'));
+            return done();
+        });
+        
+        it('Wrong JSON filter', function(done) {
+            assert.deepEqual(msgJson, alLogFilter.filterJson(msgJson, '{"message1":1'));
+            return done();
+        });
+        
+    });
+});

--- a/test/al_log_test.js
+++ b/test/al_log_test.js
@@ -67,6 +67,96 @@ describe('Unit Tests', function() {
             });
         });
 
+        it('Sunny case with JSON filter', function(done) {
+            let hostTypeElem = {
+                key: 'host_type',
+                value: {str: 'azure_fun'}
+            };
+            let localHostnameElem = {
+                key: 'local_hostname',
+                value: {str: 'somename'}
+            };
+            let hml = [localHostnameElem, hostTypeElem];
+            let msgs = [
+                {message:'message1', prop: 'value1', filter: 'pass'},
+                {message:'message2', prop: 'value2'},
+                {message:'messagea', prop: 'valuea', filter: 'pass'}
+            ];
+            
+            let parseFun = function(m) {
+                let messagePayload = {
+                  messageTs: 1542138053,
+                  priority: 11,
+                  progName: 'o365webhook',
+                  pid: undefined,
+                  message: JSON.stringify(m),
+                  messageType: 'json/azure.o365',
+                  messageTypeId: 'AzureActiveDirectory',
+                  messageTsUs: undefined
+                };
+                
+                return messagePayload;
+            };
+            let expectedPayload = 'eJzjesDExVmcX1qUnKqbmSIUzcWekV9cAmKK7Nw8722D+HQt112b3JI27E58JnzrtQSDkgWXDBdfTn5yYk48SGleYm6qEJcUR3F+biqIzSXBxQkSjy+pLEgV4pbiTKwqLUqNTyvNk6oSPKrxOpoBCGS5gYQSd76xmWl5alJGfn62kVm1Um5qcXFieqqSFYxlqKSjVFCUXwAUKUvMKQXz0zJzSlKLgCIFicXFSrVW/FnF+Xn6YEv0QOY5iTiC2I7JJZllqS6ZRanJJflFlaTbnYhmdyLZdgMAFp90iA==';
+            const params = {
+                    hostId: 'host-id',
+                    sourceId: 'source-id',
+                    hostmetaElems: hml,
+                    content: msgs,
+                    parseCallback: parseFun,
+                    filterJson: {filter: 'pass'}
+            };
+            alLog.buildPayload(params, function(err, payloadObject){
+                assert.equal(expectedPayload, payloadObject.payload.toString('base64'));
+                return done();
+            });
+        });
+
+        it('Sunny case with regexp filter', function(done) {
+            let hostTypeElem = {
+                key: 'host_type',
+                value: {str: 'azure_fun'}
+            };
+            let localHostnameElem = {
+                key: 'local_hostname',
+                value: {str: 'somename'}
+            };
+            let hml = [localHostnameElem, hostTypeElem];
+            let msgs = [
+                'message1',
+                'message2',
+                'messagea'
+            ];
+            
+            let parseFun = function(m) {
+                let messagePayload = {
+                  messageTs: 1542138053,
+                  priority: 11,
+                  progName: 'o365webhook',
+                  pid: undefined,
+                  message: m,
+                  messageType: 'json/azure.o365',
+                  messageTypeId: 'AzureActiveDirectory',
+                  messageTsUs: undefined
+                };
+                
+                return messagePayload;
+            };
+            let expectedPayload = 'eJzjamHi4izOLy1KTtXNTBGK5mLPyC8uATFFdm6e97ZBfLqW665Nbkkbdic+E771WoJByYJLhosvJz85MScepDQvMTdViEuKozg/NxXE5pLg4gSJx5dUFqQKcUtxJlaVFqXGp5XmSfkIHtV4Hc0ABLLcQEKJO9/YzLQ8NSkjPz/biCM3tbg4MT3V0Io/qzg/Tx+sTQ+kwknEEcR2TC7JLEt1ySxKTS7JL6okzjQjIk0DAFuCVYc=';
+            const params = {
+                    hostId: 'host-id',
+                    sourceId: 'source-id',
+                    hostmetaElems: hml,
+                    content: msgs,
+                    parseCallback: parseFun,
+                    filterRegexp: 'message[0-9]'
+            };
+            alLog.buildPayload(params, function(err, payloadObject){
+                assert.equal(expectedPayload, payloadObject.payload.toString('base64'));
+                return done();
+            });
+        });
+
         it('Too many messages ', function(done) {
             this.timeout(5000);
             var hostTypeElem = {

--- a/test/al_log_test.js
+++ b/test/al_log_test.js
@@ -54,7 +54,14 @@ describe('Unit Tests', function() {
                 return messagePayload;
             };
             var expectedPayload = 'eJzjamHi4izOLy1KTtXNTBGK5mLPyC8uATFFdm6e97ZBfLqW665Nbkkbdic+E771WoJByYJLhosvJz85MScepDQvMTdViEuKozg/NxXE5pLg4gSJx5dUFqQKcUtxJlaVFqXGp5XmSfkIHtV4Hc0ABLLcQEKJO9/YzLQ8NSkjPz/biCM3tbg4MT3V0Io/qzg/Tx+sTQ+kwknEEcR2TC7JLEt1ySxKTS7JL6okzjQjIk0DAFuCVYc=';
-            alLog.buildPayload('host-id', 'source-id', hml, msgs, parseFun, function(err, payloadObject){
+            const params = {
+                    hostId: 'host-id',
+                    sourceId: 'source-id',
+                    hostmetaElems: hml,
+                    content: msgs,
+                    parseCallback: parseFun
+            };
+            alLog.buildPayload(params, function(err, payloadObject){
                 assert.equal(expectedPayload, payloadObject.payload.toString('base64'));
                 return done();
             });
@@ -91,7 +98,15 @@ describe('Unit Tests', function() {
                 messagePayload.message = JSON.stringify(messagePayload);
                 return messagePayload;
             };
-            alLog.buildPayload('host-id', 'source-id', hml, msgs, parseFun, function(err, payload){
+            
+            const params = {
+                    hostId: 'host-id',
+                    sourceId: 'source-id',
+                    hostmetaElems: hml,
+                    content: msgs,
+                    parseCallback: parseFun
+            };
+            alLog.buildPayload(params, function(err, payload){
                 sinon.match(err, 'Maximum payload size exceeded');
                 return done();
             });
@@ -125,7 +140,15 @@ describe('Unit Tests', function() {
                 
                 return messagePayload;
             };
-            alLog.buildPayload('host-id', 'source-id', hml, msgs, parseFun, function(err, payload){
+            
+            const params = {
+                    hostId: 'host-id',
+                    sourceId: 'source-id',
+                    hostmetaElems: hml,
+                    content: msgs,
+                    parseCallback: parseFun
+            };
+            alLog.buildPayload(params, function(err, payload){
                 assert.equal(err, 'elem.key: string expected');
                 return done();
             });
@@ -156,7 +179,15 @@ describe('Unit Tests', function() {
                 
                 return messagePayload;
             };
-            alLog.buildPayload('host-id', 'source-id', hml, msgs, parseFun, function(err, payload){
+            
+            const params = {
+                    hostId: 'host-id',
+                    sourceId: 'source-id',
+                    hostmetaElems: hml,
+                    content: msgs,
+                    parseCallback: parseFun
+            };
+            alLog.buildPayload(params, function(err, payload){
                 assert.equal(err, 'messageTs: integer|Long expected');
                 return done();
             });

--- a/test/azcollectc_test.js
+++ b/test/azcollectc_test.js
@@ -207,7 +207,6 @@ describe('Unit Tests', function() {
             
             fakePost = sinon.stub(AzcollectC.prototype, 'post').callsFake(
                 function fakeFn(path, options) {
-                    console.log('!!!!FAKE POST', path);
                     return new Promise(function(resolve, reject) {
                         resolve('ok');
                     });


### PR DESCRIPTION
### Solution Description
Change al_log functions interfaces to be like `(params, callback)` where `params` is an object with input parameters. 
Add two new params to `buildPayload()` to pass JSON and RegExp filters. If input messages are JSON objects then  JSON filter is applied first and then RegExp filter is applied on a stringified messages. If input messages are Strings then JSON filter should not be used.