### PR TITLE
Added maxTimeRetry and encoded the stream 

### DIFF
--- a/al_util.js
+++ b/al_util.js
@@ -15,6 +15,7 @@ let MAX_CONNS_PER_SERVICE = 128;
 
 /**
  * @default Refer to https://www.npmjs.com/package/retry
+ * set maxRetryTime to 240seconds(4min) to avoid lambda timeout.
  */
 let DEFAULT_RETRY = {
     // Default values
@@ -22,7 +23,8 @@ let DEFAULT_RETRY = {
     factor: 7,
     minTimeout: 300,
     retries: 2,
-    maxTimeout: 10000
+    maxTimeout: 10000,
+    maxRetryTime: 240000 // Maximum time to spend retrying in milliseconds.
 };
 
 /**

--- a/al_util.js
+++ b/al_util.js
@@ -15,7 +15,7 @@ let MAX_CONNS_PER_SERVICE = 128;
 
 /**
  * @default Refer to https://www.npmjs.com/package/retry
- * set maxRetryTime to 240seconds(4min) to avoid lambda timeout.
+ * set maxRetryTime to 180seconds(3min) to avoid lambda timeout.
  */
 let DEFAULT_RETRY = {
     // Default values
@@ -24,7 +24,7 @@ let DEFAULT_RETRY = {
     minTimeout: 300,
     retries: 2,
     maxTimeout: 10000,
-    maxRetryTime: 240000 // Maximum time to spend retrying in milliseconds.
+    maxRetryTime: 180000 // Maximum time to spend retrying in milliseconds.
 };
 
 /**

--- a/collector_statusc.js
+++ b/collector_statusc.js
@@ -31,7 +31,9 @@ class CollectorStatusC extends AlServiceC {
             },
             body: data
         };
-        return this.put(`/statuses/${statusId}/streams/${stream}`, payload);
+        // Few collector stream contain `/` which not excepted by collectors_status service. so Encode the stream before making the api call.It will encodes special characters including: , / ? : @ & = + $ # 
+        const encodedStream = encodeURIComponent(stream);
+        return this.put(`/statuses/${statusId}/streams/${encodedStream}`, payload);
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-collector-js",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "license": "MIT",
   "description": "Alert Logic Collector Common Library",
   "repository": {

--- a/test/al_mock.js
+++ b/test/al_mock.js
@@ -159,6 +159,10 @@ const AIMS_RESPONSE_200 = {
           }
         };
 
+const SERVER_ERROR_500 = {
+    statusCode: 500,
+    message: "Internal Server Error"
+};
 function gen_auth_response() {
     return {
         authentication : {
@@ -188,6 +192,7 @@ module.exports = {
     AZURE_CHECKIN_VALUES: AZURE_CHECKIN_VALUES,
     SEND_COLLECTOR_STATUS_BODY_DATA: SEND_COLLECTOR_STATUS_BODY_DATA,
     COLLECTOR_STATUS_API: COLLECTOR_STATUS_API,
+    SERVER_ERROR_500: SERVER_ERROR_500,
 
     gen_auth_response : gen_auth_response
 };

--- a/test/collector_statusc_test.js
+++ b/test/collector_statusc_test.js
@@ -54,6 +54,24 @@ describe('Unit Tests', function () {
             });
         });
 
+        it('it should encode the stream if it contain special char', function (done) {
+            let stream = 'projects/appliance-builds';
+            const encodedStream = encodeURIComponent(stream);
+            fakePut = sinon.stub(AlServiceC.prototype, 'put').callsFake(
+                function fakeFn(path, extraOptions) {
+                    assert.equal(extraOptions.body, m_alMock.SEND_COLLECTOR_STATUS_BODY_DATA);
+                    assert.equal(path, `/statuses/${m_alMock.SEND_COLLECTOR_STATUS_BODY_DATA.status_id}/streams/${encodedStream}`);
+                    done();
+                });
+
+            var aimsc = new AimsC(m_alMock.AL_API, m_alMock.AIMS_CREDS);
+            var collectorStatus = new CollectorStatusC(m_alMock.COLLECTOR_STATUS_API, aimsc);
+            m_alMock.SEND_COLLECTOR_STATUS_BODY_DATA.stream = stream;
+            collectorStatus.sendStatus(m_alMock.SEND_COLLECTOR_STATUS_BODY_DATA.status_id, m_alMock.SEND_COLLECTOR_STATUS_BODY_DATA.stream, m_alMock.SEND_COLLECTOR_STATUS_BODY_DATA).then(res => {
+                fakePut.restore();
+            });
+        });
+
         it('If sequence of parameter is not correct then api throw the error', function (done) {
             const error = {
                 "errorinfo": {


### PR DESCRIPTION
### Problem Description

1. Collector service return 501 error while validating url because stream contain `/`  which is not excepted.
"[api_key:undefined]10.0.0.136 _ - "put /collectors_status/v1/134224120/statuses/72931B10-3E38-493C-B3E0-F21C862500F0/streams/**projects/imran-49253**  HTTP/1.1" **501** 0 "

2. If there is server error we do retry twice after actual call and some time it take much time which result into lambda time out(default time provided as 5min for lambda). Due to which duplication of SQS message happened.



### Solution Description
1.Encode the stream value while making the api call.
2. By default value of maxRetryTime is forever , so updating it to 3min.