### PR TITLE
 Fix to parse timestamp in milli seconds and Date format both in parseTs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-collector-js",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "license": "MIT",
   "description": "Alert Logic Collector Common Library",
   "repository": {
@@ -21,10 +21,10 @@
   ],
   "devDependencies": {
     "jshint": "^2.13.6",
-    "mocha": "^10.4.0",
+    "mocha": "^10.7.0",
     "mocha-jenkins-reporter": "^0.4.8",
     "nock": "^13.5.4",
-    "nyc": "^15.1.0",
+    "nyc": "^17.0.0",
     "rewire": "^7.0.0",
     "sinon": "^18.0.0",
     "timekeeper": "^2.3.1"

--- a/parse.js
+++ b/parse.js
@@ -30,8 +30,8 @@ var defaultTs = function() {
     };
 };
 
-var parseTs = function(ts) {
-    var milli = Date.parse(ts);
+var parseTs = function (ts) {
+    var milli = typeof ts === 'number' ? ts : Date.parse(ts);
     if (isNaN(milli)) {
         return defaultTs();
     } else {

--- a/test/parse_test.js
+++ b/test/parse_test.js
@@ -135,6 +135,13 @@ describe('Common parse functions unit tests.', function() {
         assert.deepEqual(privParseTs('foo'), { sec: 1234567, usec: null });
         done();
     });
+
+    it('timestamp input in milliseconds', function (done) {
+        let parseWire1 = rewire('../parse');
+        var privParseTs = parseWire1.__get__('parseTs');
+        assert.deepEqual(privParseTs(1721143248000), { sec: 1721143248, usec: null });
+        done();
+    });
     
     it('iteratePropPaths zero key', function(done) {
         const testPaths = [


### PR DESCRIPTION
### Problem Description
 Fix to parse timestamp in milli seconds and Date format in parseTs
### Solution Description
Some 3rd party apis send timestamp directly in milliseconds like (ciscoduo , s3 imperva logs) so made changes in parseTs to handle both milliseconds and Date format parsing.
```
[
  {
    "@timestamp": 1721143248000,
    "event": {
      "id": "1",
      "provider": "abp",
      "dataset": "ABP",
      "category": "web",
      "code": "allow"
    }},
    {
    "@timestamp": 1721143248001,
    "event": {
      "id": "2",
      "provider": "abp",
      "dataset": "ABP",
      "category": "web",
      "code": "allow"
    }}
]
```