### PR TITLE
Timestamp issues(handling milliseconds,seconds, and date string) fixed for ciscoduo and other collectors, moved httpagents to top of code

### DIFF
--- a/al_util.js
+++ b/al_util.js
@@ -13,6 +13,7 @@ const http = require('http');
 const https = require('https');
 
 let MAX_CONNS_PER_SERVICE = 128;
+let MAX_FREE_SOCKETS = 10;
 
 /**
  * @default Refer to https://www.npmjs.com/package/retry
@@ -32,9 +33,12 @@ let DEFAULT_RETRY = {
  */
 let DEFAULT_HTTP_HTTPS_AGENT_CONFIG = {
     keepAlive: true,
-    maxSockets: MAX_CONNS_PER_SERVICE,   // Maximum number of sockets to open
+    maxSockets: process.env.MAX_CONNS_PER_SERVICE || MAX_CONNS_PER_SERVICE, // Maximum number of sockets to open
+    maxFreeSockets: process.env.MAX_FREE_SOCKETS || MAX_FREE_SOCKETS   //sets the maximum number of sockets that will be left open in the free state
 };
 
+const httpAgent = new http.Agent(DEFAULT_HTTP_HTTPS_AGENT_CONFIG);
+const httpsAgent = new https.Agent(DEFAULT_HTTP_HTTPS_AGENT_CONFIG);
 
 /**
  * @function Default retry callback.
@@ -79,8 +83,8 @@ class RestServiceClient {
             url: this._url + path,
             headers: {},
             json: true,
-            httpAgent: new http.Agent(DEFAULT_HTTP_HTTPS_AGENT_CONFIG),
-            httpsAgent: new https.Agent(DEFAULT_HTTP_HTTPS_AGENT_CONFIG)
+            httpAgent: httpAgent,
+            httpsAgent: httpsAgent
         };
         const options = Object.assign({}, defaultOptions, extra);
         const defaultHeaders = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-collector-js",
-  "version": "3.0.13",
+  "version": "3.0.14",
   "license": "MIT",
   "description": "Alert Logic Collector Common Library",
   "repository": {

--- a/parse.js
+++ b/parse.js
@@ -15,6 +15,9 @@
  * For the ISO8601 timestamp, '2018-12-19T08:18:21.1834546Z'
  */
 const ISO8601_MICROSEC_OFFSET = 20;
+const MILLISECONDS_SINCE_EPOCH = 1000000000000;
+const MAX_MILLISECONDS_SINCE_EPOCH = 9999999999999;
+const SECONDS_SINCE_EPOCH = 1000000000;
 
 var getProp = function(path, obj, defaultVal = null) {
     var reduceFun = function(xs, x) {
@@ -31,11 +34,27 @@ var defaultTs = function() {
 };
 
 var parseTs = function (ts) {
-    var milli = typeof ts === 'number' ? ts : Date.parse(ts);
-    if (isNaN(milli)) {
+    // Handle numeric timestamp (seconds or milliseconds)
+    if (typeof ts === 'number') {
+        if (ts >= MILLISECONDS_SINCE_EPOCH && ts <= MAX_MILLISECONDS_SINCE_EPOCH) {
+            return {
+                sec: Math.floor(ts / 1000),
+                usec: (ts % 1000) * 1000 || null
+            };
+        }
+        if (ts >= SECONDS_SINCE_EPOCH && ts <= MILLISECONDS_SINCE_EPOCH) {
+            return {
+                sec: ts,
+                usec: null
+            };
+        }
         return defaultTs();
     } else {
-        var micro = parseTsUsec(ts);
+        const milli = Date.parse(ts);
+        const micro = parseTsUsec(ts);
+        if (isNaN(milli)) {
+            return defaultTs();
+        }
         return {
             sec: Math.floor(milli / 1000),
             usec: micro

--- a/test/parse_test.js
+++ b/test/parse_test.js
@@ -20,7 +20,7 @@ describe('Common parse functions unit tests.', function() {
     var clock;
     
     before(function() {
-        clock = sinon.useFakeTimers({now: 1234567890});
+        clock = sinon.useFakeTimers({now: 1234567890000});
     });
     after(function() {
         clock.restore();
@@ -132,7 +132,7 @@ describe('Common parse functions unit tests.', function() {
     it('Wrong timestamp input', function (done) {
         let parseWire1 = rewire('../parse');
         var privParseTs = parseWire1.__get__('parseTs');
-        assert.deepEqual(privParseTs('foo'), { sec: 1234567, usec: null });
+        assert.deepEqual(privParseTs('foo'), { sec: 1234567890, usec: null });
         done();
     });
 
@@ -140,6 +140,34 @@ describe('Common parse functions unit tests.', function() {
         let parseWire1 = rewire('../parse');
         var privParseTs = parseWire1.__get__('parseTs');
         assert.deepEqual(privParseTs(1721143248000), { sec: 1721143248, usec: null });
+        done();
+    });
+    
+    it('timestamp input in microseconds 1721143248000000', function (done) {
+        let parseWire1 = rewire('../parse');
+        var privParseTs = parseWire1.__get__('parseTs');
+        assert.deepEqual(privParseTs(1721143248000000), { sec: 1234567890, usec: null });
+        done();
+    });
+
+    it('timestamp input in seconds', function (done) {
+        let parseWire1 = rewire('../parse');
+        var privParseTs = parseWire1.__get__('parseTs');
+        assert.deepEqual(privParseTs(1721143248), { sec: 1721143248, usec: null });
+        done();
+    });
+
+    it('timestamp input in the string form example 2018-12-19T08:18:21.1834546Z', function (done) {
+        let parseWire1 = rewire('../parse');
+        var privParseTs = parseWire1.__get__('parseTs');
+        assert.deepEqual(privParseTs('2018-12-19T08:18:21.1834546Z'), { sec: 1545207501, usec: 183454 });
+        done();
+    });
+
+    it('timestamp input in the string form example 2024-09-17T23:56:26.429270+00:00', function (done) {
+        let parseWire1 = rewire('../parse');
+        var privParseTs = parseWire1.__get__('parseTs');
+        assert.deepEqual(privParseTs('2024-09-17T23:56:26.429270+00:00'), { sec: 1726617386, usec: 429270 });
         done();
     });
     


### PR DESCRIPTION
### Problem Description

Problem : 
1)Wrong messageTs value while sending to ingest. Ingest not ingesting data due to incorrect date format. There is changes in tsparse function in [pr](https://github.com/alertlogic/al-collector-js/pull/61) . Which expecting the milliseconds but cisco duo having timestamp in seconds, so it divided by 1000 and sending wrong value in sec while sending to ingest.
2) Create http and https agent outside of RestClient to create only once the agent instance and modify Maxsockets and add Max free sockets to config.

### Solution Description
1) Fixed Timestamp issues(handling milliseconds,seconds, and date string) for ciscoduo and other collectors
2) Moved creation of http and https agent to top of the code to reuse existing http and https agents instead of creating new evertime creating rest client.
let DEFAULT_HTTP_HTTPS_AGENT_CONFIG = {
    keepAlive: true,
    maxSockets: process.env.MAX_CONNS_PER_SERVICE || MAX_CONNS_PER_SERVICE, // Maximum number of sockets to open
    maxFreeSockets: process.env.MAX_FREE_SOCKETS || MAX_FREE_SOCKETS   //sets the maximum number of sockets that will be left open in the free state
};

const httpAgent = new http.Agent(DEFAULT_HTTP_HTTPS_AGENT_CONFIG);
const httpsAgent = new https.Agent(DEFAULT_HTTP_HTTPS_AGENT_CONFIG);