### PR TITLE
[al-collector-js]Npm packages updated for vulnerability fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-collector-js",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "license": "MIT",
   "description": "Alert Logic Collector Common Library",
   "repository": {
@@ -21,23 +21,23 @@
   ],
   "devDependencies": {
     "jshint": "^2.13.6",
-    "mocha": "^10.7.0",
+    "mocha": "^10.8.2",
     "mocha-jenkins-reporter": "^0.4.8",
-    "nock": "^13.5.4",
-    "nyc": "^17.0.0",
+    "nock": "^13.5.6",
+    "nyc": "^17.1.0",
     "rewire": "^7.0.0",
     "sinon": "^18.0.1",
     "timekeeper": "^2.3.1"
   },
   "dependencies": {
     "async": "3.2.6",
-    "axios": "^1.7.7",
-    "debug": "4.3.7",
+    "axios": "^1.8.4",
+    "debug": "4.4.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.filter": "^4.6.0",
     "lodash.remove": "^4.7.0",
     "moment": "2.30.1",
-    "protobufjs": "^7.3.0",
+    "protobufjs": "^7.4.0",
     "retry": "0.13.1"
   },
   "author": "Alert Logic Inc."


### PR DESCRIPTION
### Problem Description
Update the Dependancy due to which below vulnerability are found :
Customer had provided 4 vulnerabilities that they have detected against the GuardDuty Collector
CVEs:
CVE-2024-21538
CVE-2024-57965
CVE-2025-27152
CVE-2025-27789


### Solution Description
npm packages are updated to fix above CVEs

1. "mocha": "^10.8.2"
2. "nock": "^13.5.6"
3. "nyc": "^17.1.0"
4. "axios": "^1.8.4"
5. "debug": "4.4.0"
6. "protobufjs": "^7.4.0"