### PR TITLE
Update NodeJS version to 22 and fix npm Vulnerabilities reported by A…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-collector-js",
-  "version": "3.0.15",
+  "version": "3.0.16",
   "license": "MIT",
   "description": "Alert Logic Collector Common Library",
   "repository": {
@@ -25,14 +25,14 @@
     "mocha-jenkins-reporter": "^0.4.8",
     "nock": "^13.5.6",
     "nyc": "^17.1.0",
-    "rewire": "^7.0.0",
+    "rewire": "^9.0.1",
     "sinon": "^18.0.1",
     "timekeeper": "^2.3.1"
   },
   "dependencies": {
     "async": "3.2.6",
-    "axios": "^1.8.4",
-    "debug": "4.4.0",
+    "axios": "^1.11.0",
+    "debug": "^4.4.1",
     "lodash.clonedeep": "^4.5.0",
     "lodash.filter": "^4.6.0",
     "lodash.remove": "^4.7.0",

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -8,7 +8,7 @@ stages:
             - pull_request
             - pull_request:
                 trigger_phrase: test it
-        image: node:20
+        image: node:22
         compute_size: small
         commands:
             - make test
@@ -16,7 +16,7 @@ stages:
         name: Master Push - Publish
         when:
             - push: ['npm']
-        image: node:20
+        image: node:22
         compute_size: small
         commands:
             - make test


### PR DESCRIPTION
### Problem Description
Update NodeJS version to 22 and fix Vulnerabilities reported by AWS inspector 

### Solution Description
Fixed by bumping npm packages versions
"axios": "^1.11.0",
"debug": "^4.4.1",
"rewire": "^9.0.1"
and updated node js to 22 version
    

