### PR TITLE
Fix npm package vulnerabilities identified by AWS Inspector

### DIFF
--- a/al_log_filter.js
+++ b/al_log_filter.js
@@ -7,9 +7,9 @@
  * @end
  * -----------------------------------------------------------------------------
  */
-const lodashFilter = require('lodash.filter');
-const lodashRemove = require('lodash.remove');
-const lodashcloneDeep = require('lodash.clonedeep');
+const lodashcloneDeep = require('lodash/cloneDeep');
+const lodashFilter = require('lodash/filter');
+const lodashRemove = require('lodash/remove');
 
 /**
  *  @function initializes JSON filter

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-collector-js",
-  "version": "3.0.19",
+  "version": "3.0.20",
   "license": "MIT",
   "description": "Alert Logic Collector Common Library",
   "repository": {
@@ -30,14 +30,15 @@
   },
   "dependencies": {
     "async": "3.2.6",
-    "axios": "^1.13.2",
+    "axios": "^1.13.4",
     "debug": "^4.4.3",
-    "lodash.clonedeep": "^4.5.0",
-    "lodash.filter": "^4.6.0",
-    "lodash.remove": "^4.7.0",
+    "lodash": "^4.17.23",
     "moment": "2.30.1",
     "protobufjs": "^8.0.0",
     "retry": "0.13.1"
+  },
+  "overrides": {
+    "diff": "^8.0.3"
   },
   "author": "Alert Logic Inc."
 }


### PR DESCRIPTION
Problem Description:
Multiple security vulnerabilities detected by AWS Inspector in npm dependencies including:
- Prototype pollution vulnerabilities in older lodash packages which are 9 years old.
- Denial of Service vulnerability in diff package (transitive dependency)

Solution Description:
1. Replaced individual lodash packages (lodash.clonedeep, lodash.filter, lodash.remove) 
   with unified lodash ^4.17.23 which includes fixes for:
   - CVE-2020-28500 (ReDoS vulnerability)
   - CVE-2020-8203 (Prototype Pollution in zipObjectDeep)
   - CVE-2019-10744 (Prototype Pollution in defaultsDeep)

2. Updated axios from ^1.13.2 to ^1.13.4 for security patches

3. Added package override for diff ^8.0.3 to fix GHSA-73rr-hh4g-fpgx 
   (Denial of Service vulnerability in parsePatch and applyPatch)

4. Updated al_log_filter.js to use destructured imports from unified lodash package