### PR TITLE
[ENG-60146]: Security Vulnerability Fix: NPM Dependencies shown by AWS inspector

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,6 @@
 {
   "eqeqeq": true,
-  "esversion": 6,
+  "esversion": 11,
   "shadow": "outer",
   "undef": true,
   "unused": "vars",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-collector-js",
-  "version": "3.0.20",
+  "version": "3.0.21",
   "license": "MIT",
   "description": "Alert Logic Collector Common Library",
   "repository": {
@@ -30,15 +30,17 @@
   },
   "dependencies": {
     "async": "3.2.6",
-    "axios": "^1.13.4",
+    "axios": "^1.15.0",
     "debug": "^4.4.3",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.1",
     "moment": "2.30.1",
     "protobufjs": "^8.0.0",
     "retry": "0.13.1"
   },
   "overrides": {
-    "diff": "^8.0.3"
+    "diff": "^8.0.3",
+    "serialize-javascript": "^7.0.5",
+    "minimatch": "^3.1.4"
   },
   "author": "Alert Logic Inc."
 }


### PR DESCRIPTION
### Problem Description
Story :https://helpsystems.atlassian.net/browse/ENG-60146
Multiple high-severity security vulnerabilities detected in npm dependencies:


1. lodash ≤4.17.23 (Severity: High)

- Code Injection via _.template imports key names
- https://github.com/advisories/GHSA-r5fr-rjxr-66jc
- Prototype Pollution via array path bypass in _.unset and _.omit
- https://github.com/advisories/GHSA-f23m-r3pf-42rh
- Affected path: jshint → lodash (devDependency transitive)

2. minimatch ≤3.1.3 (Severity: High)

- ReDoS via repeated wildcards with non-matching literal in pattern
- https://github.com/advisories/GHSA-3ppc-4f35-3m26
- ReDoS: matchOne() combinatorial backtracking via multiple non-adjacent GLOBSTAR segments
- https://github.com/advisories/GHSA-7r86-cg39-jmmj
- ReDoS: nested *() extglobs generate catastrophically backtracking regular expressions
- https://github.com/advisories/GHSA-23c5-xmqv-rm74
- Affected path: jshint → minimatch (devDependency transitive)

3. serialize-javascript ≤7.0.4 (Severity: High)

- RCE via RegExp.flags and Date.prototype.toISOString()
- https://github.com/advisories/GHSA-5c6j-r48x-rmvq
- CPU Exhaustion DoS via crafted array-like objects
- https://github.com/advisories/GHSA-qj8w-gfj5-8c6v
- Affected path: mocha → serialize-javascript (devDependency transitive)

4. Axios <1.15.0 ((Severity: High)
- https://github.com/advisories/GHSA-3p68-rc4w-qgx5

### Solution Description
Updated npm dependency overrides to enforce patched versions:

1. lodash: ≤4.17.23 → ^4.18.1 (Override for jshint transitive dependency)
2. minimatch: ≤3.1.3 → ^3.1.4 (Override to patch ReDoS vulnerabilities)
3. serialize-javascript: ≤7.0.4 → ^7.0.5 (Override to patch RCE and DoS vulnerabilities)
4. axios:<1.13.4->^1.15.0

