### PR TITLE
Added CLI trigger for package builds and update node version to 24 in ps_spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alertlogic/al-collector-js",
-  "version": "3.0.22",
+  "version": "3.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alertlogic/al-collector-js",
-      "version": "3.0.22",
+      "version": "3.0.23",
       "license": "MIT",
       "dependencies": {
         "async": "3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-collector-js",
-  "version": "3.0.22",
+  "version": "3.0.23",
   "license": "MIT",
   "description": "Alert Logic Collector Common Library",
   "repository": {

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -8,7 +8,7 @@ stages:
             - pull_request
             - pull_request:
                 trigger_phrase: test it
-        image: node:22
+        image: node:24
         compute_size: small
         commands:
             - make test
@@ -16,7 +16,8 @@ stages:
         name: Master Push - Publish
         when:
             - push: ['npm']
-        image: node:22
+            - cli: build
+        image: node:24
         compute_size: small
         commands:
             - make test


### PR DESCRIPTION
**Problem**
Added CLI trigger for package builds, no way to trigger build if npm token expires
Update nodejs version to 24 in ps_spec.yml
**Solution**
Add a CLI trigger for package builds using ALPS CLI
Updated nodejs version to 24 in ps_spec.yml

